### PR TITLE
fix(tts): BE-BUG-2/3/4 — error logging, serial TTS queue, stream_token WS forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to DesktopMatePlus Backend will be documented in this file.
 
+## [2.3.1] - 2026-04-01
+
+### Fixed
+- Fish Speech error logs are no longer silently swallowed — `logger.error` restored in the `except` block so TTS failures are visible ([3fe1836])
+- Fish Speech TTS now serializes synthesis requests through an `asyncio.Queue` worker — concurrent synthesis calls no longer race, and hung requests time out after 120s ([3fe1836])
+- `stream_token` events are now forwarded to WebSocket clients in addition to the internal STM event bus — the frontend can display text as it streams ([3fe1836])
+
 ## [2.3.0] - 2026-03-31
 
 ### Fixed

--- a/src/main.py
+++ b/src/main.py
@@ -89,6 +89,8 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 initialize_mongodb_client,
                 initialize_tts_service,
             )
+            from src.services.service_manager import get_tts_service
+            from src.services.tts_service.fish_speech import FishSpeechTTS
 
             print("\n📋 Loading service configurations...")
 
@@ -98,6 +100,10 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
             else:
                 print("  - TTS config: Using default")
                 initialize_tts_service()
+
+            _tts = get_tts_service()
+            if isinstance(_tts, FishSpeechTTS):
+                await _tts.start_worker()
 
             initialize_emotion_motion_mapper()
 
@@ -214,6 +220,15 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
     ) -> None:
         if sweep_service is not None:
             await sweep_service.stop()
+        try:
+            from src.services.service_manager import get_tts_service
+            from src.services.tts_service.fish_speech import FishSpeechTTS
+
+            _tts = get_tts_service()
+            if isinstance(_tts, FishSpeechTTS):
+                await _tts.stop_worker()
+        except Exception:
+            pass
         print(f"👋 Shutting down {settings.app_name}")
 
     @asynccontextmanager

--- a/src/services/tts_service/fish_speech.py
+++ b/src/services/tts_service/fish_speech.py
@@ -1,5 +1,7 @@
+import asyncio
 import base64
 import contextlib
+from concurrent.futures import Future as ConcurrentFuture
 from typing import Annotated, Literal
 
 import ormsgpack
@@ -54,6 +56,7 @@ class FishSpeechTTS(TTSService):
     """
     외부 TTS API와 통신하여 텍스트로부터 음성을 생성하는 서비스입니다.
     텍스트 처리부터 API 요청까지 모든 과정을 캡슐화합니다.
+    직렬 큐 워커를 통해 동시 요청을 순차적으로 처리합니다.
     """
 
     def __init__(
@@ -99,7 +102,43 @@ class FishSpeechTTS(TTSService):
         self.repetition_penalty = repetition_penalty
         self.temperature = temperature
 
+        # Serial queue worker — initialized by start_worker() in async lifespan
+        self._queue: asyncio.Queue | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._worker_task: asyncio.Task | None = None
+
         logger.info(f"FishTTS initialized at {self.base_url}")
+
+    async def start_worker(self) -> None:
+        """Start the serial TTS queue worker. Must be called from async context (lifespan)."""
+        self._loop = asyncio.get_running_loop()
+        self._queue = asyncio.Queue()
+        self._worker_task = asyncio.create_task(self._serial_worker())
+        logger.info("FishSpeechTTS serial queue worker started")
+
+    async def stop_worker(self) -> None:
+        """Stop the serial queue worker."""
+        if self._worker_task:
+            self._worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._worker_task
+            self._worker_task = None
+        self._queue = None
+        self._loop = None
+
+    async def _serial_worker(self) -> None:
+        """Process TTS HTTP requests one at a time from the queue."""
+        while True:
+            payload, loop_future = await self._queue.get()
+            try:
+                result = await asyncio.to_thread(self._request_tts_stream, payload)
+                if not loop_future.done():
+                    loop_future.set_result(result)
+            except Exception as e:
+                if not loop_future.done():
+                    loop_future.set_exception(e)
+            finally:
+                self._queue.task_done()
 
     def _request_tts_stream(self, request_payload: ServeTTSRequest) -> bytes | None:
         """
@@ -122,16 +161,15 @@ class FishSpeechTTS(TTSService):
                     "authorization": f"Bearer {self.api_key or ''}",
                     "content-type": "application/msgpack",
                 },
-                timeout=30,
+                timeout=120,
             )
             response.raise_for_status()
-            # logger.info(f"음성 데이터 생성 성공 ({len(response.content)} bytes)")
             return bytes(response.content)
-        except requests.exceptions.RequestException:
-            # logger.error(f"TTS API 요청 실패: {e}")
+        except requests.exceptions.RequestException as e:
+            logger.error(f"TTS API 요청 실패: {e}")
             return None
-        except Exception:
-            # logger.error(f"TTS 처리 중 예상치 못한 오류: {e}")
+        except Exception as e:
+            logger.error(f"TTS 처리 중 예상치 못한 오류: {e}")
             return None
 
     def generate_speech(
@@ -144,6 +182,7 @@ class FishSpeechTTS(TTSService):
     ) -> bytes | str | bool | None:
         """
         [메인 메서드] 원본 텍스트를 받아 음성을 생성하고 지정된 포맷으로 반환합니다.
+        큐 워커가 실행 중이면 직렬 처리, 아니면 직접 호출합니다.
 
         Args:
             raw_text: LLM으로부터 받은 원본 텍스트
@@ -162,7 +201,6 @@ class FishSpeechTTS(TTSService):
         # 1. TTS로 처리할 텍스트가 있는지 확인
         tts_text = text.strip()
         if not tts_text:
-            # logger.info("TTS로 처리할 내용이 없어 스킵합니다.")
             return None
 
         # 3. API 요청 페이로드 생성
@@ -170,8 +208,15 @@ class FishSpeechTTS(TTSService):
             text=tts_text, reference_id=reference_id, format=audio_format
         )
 
-        # 4. API 호출하여 오디오 데이터 획득
-        audio_bytes = self._request_tts_stream(request_payload)
+        # 4. 큐 워커가 활성화된 경우 직렬 처리, 아니면 직접 호출
+        if (
+            self._loop is not None
+            and self._queue is not None
+            and self._loop.is_running()
+        ):
+            audio_bytes = self._enqueue_and_wait(request_payload)
+        else:
+            audio_bytes = self._request_tts_stream(request_payload)
 
         if not audio_bytes:
             return None
@@ -183,13 +228,30 @@ class FishSpeechTTS(TTSService):
             try:
                 with open(output_filename, "wb") as f:
                     f.write(audio_bytes)
-                # logger.info(f"음성 파일이 성공적으로 생성되었습니다: {output_filename}")
                 return True
             except Exception:
-                # logger.error(f"파일 저장 오류: {e}")
                 return False
         else:  # "bytes"가 기본값
             return audio_bytes
+
+    def _enqueue_and_wait(self, request_payload: ServeTTSRequest) -> bytes | None:
+        """Submit payload to async queue from sync thread context and wait for result."""
+        loop = self._loop
+        queue = self._queue
+
+        async def _submit() -> bytes | None:
+            loop_future: asyncio.Future = loop.create_future()
+            await queue.put((request_payload, loop_future))
+            return await loop_future
+
+        try:
+            concurrent_future: ConcurrentFuture = asyncio.run_coroutine_threadsafe(
+                _submit(), loop
+            )
+            return concurrent_future.result(timeout=120)
+        except Exception as e:
+            logger.error(f"TTS 큐 처리 중 오류: {e}")
+            return None
 
     def list_voices(self) -> list[str]:
         """FishSpeech does not manage reference voice directories."""

--- a/src/services/websocket_service/message_processor/event_handlers.py
+++ b/src/services/websocket_service/message_processor/event_handlers.py
@@ -45,6 +45,7 @@ class EventHandler:
 
                 if event_type == "stream_token":
                     await self._put_token_event(turn_id, event)
+                    await self.processor._put_event(turn_id, event)
                     continue
 
                 if event_type == "stream_start":

--- a/tests/core/test_message_processor.py
+++ b/tests/core/test_message_processor.py
@@ -141,10 +141,11 @@ async def test_agent_stream_events_forwarded(processor: MessageProcessor):
 
     assert [e["type"] for e in events] == [
         "stream_start",
+        "stream_token",
         "tts_chunk",
         "stream_end",
     ]
-    assert events[1]["text"] == "Hello"
+    assert events[2]["text"] == "Hello"
     assert processor.get_event_queue(turn_id) is None
     assert processor.turns[turn_id].status == TurnStatus.COMPLETED
 

--- a/tests/services/test_fish_speech.py
+++ b/tests/services/test_fish_speech.py
@@ -1,0 +1,114 @@
+"""Tests for FishSpeechTTS — BE-BUG-2 (logger restore) and BE-BUG-3 (serial queue)."""
+
+import threading
+from asyncio import to_thread
+from unittest.mock import patch
+
+import requests
+
+from src.services.tts_service.fish_speech import FishSpeechTTS, ServeTTSRequest
+
+
+class TestFishSpeechLoggerRestore:
+    """BE-BUG-2: logger.error must be called on exceptions in _request_tts_stream."""
+
+    def _make_tts(self) -> FishSpeechTTS:
+        return FishSpeechTTS(base_url="http://localhost:8080")
+
+    def test_request_exception_logs_error(self) -> None:
+        """RequestException in _request_tts_stream → logger.error called."""
+        tts = self._make_tts()
+        with patch("src.services.tts_service.fish_speech.requests.post") as mock_post:
+            mock_post.side_effect = requests.exceptions.RequestException(
+                "connection refused"
+            )
+            with patch("src.services.tts_service.fish_speech.logger") as mock_logger:
+                result = tts._request_tts_stream(ServeTTSRequest(text="hello"))
+
+        assert result is None
+        mock_logger.error.assert_called_once()
+        assert "TTS API 요청 실패" in mock_logger.error.call_args[0][0]
+
+    def test_generic_exception_logs_error(self) -> None:
+        """Unexpected Exception in _request_tts_stream → logger.error called."""
+        tts = self._make_tts()
+        with patch("src.services.tts_service.fish_speech.requests.post") as mock_post:
+            mock_post.side_effect = RuntimeError("unexpected")
+            with patch("src.services.tts_service.fish_speech.logger") as mock_logger:
+                result = tts._request_tts_stream(ServeTTSRequest(text="hello"))
+
+        assert result is None
+        mock_logger.error.assert_called_once()
+        assert "예상치 못한 오류" in mock_logger.error.call_args[0][0]
+
+
+class TestFishSpeechSerialQueue:
+    """BE-BUG-3: Queue worker serializes concurrent TTS requests."""
+
+    async def test_start_worker_creates_running_task(self) -> None:
+        """start_worker() creates an active asyncio.Task."""
+        tts = FishSpeechTTS(base_url="http://localhost:8080")
+        await tts.start_worker()
+        assert tts._worker_task is not None
+        assert not tts._worker_task.done()
+        await tts.stop_worker()
+
+    async def test_generate_speech_via_queue_returns_bytes(self) -> None:
+        """generate_speech() returns bytes via queue worker."""
+        tts = FishSpeechTTS(base_url="http://localhost:8080")
+        fake_audio = b"fake_audio_data"
+
+        with patch.object(tts, "_request_tts_stream", return_value=fake_audio):
+            await tts.start_worker()
+            result = await to_thread(tts.generate_speech, "hello", None, "bytes")
+            await tts.stop_worker()
+
+        assert result == fake_audio
+
+    async def test_concurrent_requests_are_serialized(self) -> None:
+        """Two concurrent generate_speech() calls must NOT overlap in _request_tts_stream."""
+        tts = FishSpeechTTS(base_url="http://localhost:8080")
+
+        overlap_detected = threading.Event()
+        in_progress = threading.Event()
+        call_lock = threading.Lock()
+
+        def controlled_http(payload: ServeTTSRequest) -> bytes:
+            with call_lock:
+                if in_progress.is_set():
+                    overlap_detected.set()
+                in_progress.set()
+            import time
+
+            time.sleep(0.05)  # simulate HTTP latency
+            with call_lock:
+                in_progress.clear()
+            return b"audio"
+
+        with patch.object(tts, "_request_tts_stream", side_effect=controlled_http):
+            await tts.start_worker()
+            await __import__("asyncio").gather(
+                to_thread(tts.generate_speech, "first"),
+                to_thread(tts.generate_speech, "second"),
+            )
+            await tts.stop_worker()
+
+        assert (
+            not overlap_detected.is_set()
+        ), "Concurrent HTTP calls detected — not serialized!"
+
+    def test_timeout_is_120s(self) -> None:
+        """_request_tts_stream uses timeout=120."""
+        tts = FishSpeechTTS(base_url="http://localhost:8080")
+        captured: dict = {}
+
+        def mock_post(*args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            raise requests.exceptions.RequestException("mock")
+
+        with patch(
+            "src.services.tts_service.fish_speech.requests.post", side_effect=mock_post
+        ):
+            tts._request_tts_stream(ServeTTSRequest(text="test"))
+
+        assert captured.get("timeout") == 120

--- a/tests/websocket/test_stream_token_forward.py
+++ b/tests/websocket/test_stream_token_forward.py
@@ -1,0 +1,58 @@
+"""BE-BUG-4: stream_token events must be forwarded to WS clients in addition to token queue."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from src.services.websocket_service.message_processor.event_handlers import EventHandler
+
+
+async def _make_stream(events: list[dict]):
+    """Async generator yielding given events."""
+    for e in events:
+        yield e
+
+
+class TestStreamTokenForward:
+    """BE-BUG-4: stream_token forwarded to processor._put_event after _put_token_event."""
+
+    async def test_stream_token_is_forwarded_to_ws_client(self) -> None:
+        """After _put_token_event, processor._put_event must also be called for stream_token."""
+        processor = MagicMock()
+        processor._normalize_event = lambda turn_id, raw: raw
+        processor._put_event = AsyncMock()
+        processor.update_turn_status = AsyncMock()
+        processor.complete_turn = AsyncMock()
+        processor.fail_turn = AsyncMock()
+        processor._wait_for_tts_tasks = AsyncMock()
+        processor.is_connection_closing = MagicMock(return_value=False)
+
+        # Token queue mock
+        token_queue = AsyncMock()
+        token_queue.put = AsyncMock()
+        token_queue.qsize = MagicMock(return_value=0)
+        turn = MagicMock()
+        turn.token_queue = token_queue
+        turn.token_stream_closed = False
+        processor.turns = {"turn-1": turn}
+
+        handler = EventHandler(processor)
+        handler._put_token_event = AsyncMock()
+        handler._signal_token_stream_closed = AsyncMock()
+        handler._wait_for_token_queue = AsyncMock()
+
+        token_event = {"type": "stream_token", "turn_id": "turn-1", "chunk": "hello"}
+        stream = _make_stream([token_event])
+
+        await handler.produce_agent_events("turn-1", stream)
+
+        # _put_token_event must have been called
+        handler._put_token_event.assert_called_once_with("turn-1", token_event)
+
+        # processor._put_event must ALSO have been called with the stream_token event
+        forward_calls = [
+            call
+            for call in processor._put_event.call_args_list
+            if call.args[1].get("type") == "stream_token"
+        ]
+        assert (
+            forward_calls
+        ), "stream_token event was NOT forwarded to WS client via _put_event"


### PR DESCRIPTION
## Summary

- **BE-BUG-2**: Restore `logger.error` calls in `_request_tts_stream` exception handlers — added `as e` to except clauses so the variable is bound
- **BE-BUG-3**: Add `asyncio.Queue` + single serial worker to `FishSpeechTTS` — serializes HTTP TTS calls, raises timeout 30s → 120s, hooked into lifespan via `start_worker()`/`stop_worker()`
- **BE-BUG-4**: Forward `stream_token` events to WS clients — after `_put_token_event`, also call `processor._put_event` so clients receive tokens in real-time

## Test plan

- [ ] `tests/services/test_fish_speech.py` — serial queue, timeout, error logging tests
- [ ] `tests/websocket/test_stream_token_forward.py` — WS forward tests
- [ ] Manual: TTS 요청이 직렬로 처리되는지 확인
- [ ] Manual: stream_token 이벤트가 WS 클라이언트에 도달하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)