### PR TITLE
fix(qa): resolve GP-4 hardcoded URLs and GP-3 bare print violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to DesktopMatePlus Backend will be documented in this file.
 
+## [2.4.1] - 2026-04-03
+
+### Fixed
+
+- Moved 5 hardcoded network URLs (vLLM TTS, Irodori TTS, backend, NanoClaw, OpenAI agent) to YAML config or Pydantic `Settings` with env var overrides — eliminates GP-4 violations
+- Replaced all bare `print()` calls in `src/` with Loguru logger — `logger.info/warning/error/exception` — eliminates GP-3 violations
+- Cleared `_KNOWN_PRINT_FILES` and `_KNOWN_LOCALHOST_FILES` technical-debt sets in structural architecture tests
+
 ## [2.4.0] - 2026-04-01
 
 ### Added

--- a/src/configs/settings.py
+++ b/src/configs/settings.py
@@ -1,5 +1,6 @@
 """Application settings and configuration."""
 
+import os
 from pathlib import Path
 
 import yaml
@@ -69,6 +70,16 @@ class Settings(BaseModel):
     # Health check settings
     health_check_timeout: int = Field(
         default=5, description="Timeout for health checks in seconds"
+    )
+
+    # Integration URLs (override via env vars BACKEND_URL / NANOCLAW_URL)
+    backend_url: str = Field(
+        default_factory=lambda: os.getenv("BACKEND_URL", "http://localhost:8000"),
+        description="Backend base URL for internal callback and STM endpoints",
+    )
+    nanoclaw_url: str = Field(
+        default_factory=lambda: os.getenv("NANOCLAW_URL", "http://localhost:3000"),
+        description="NanoClaw base URL for task delegation webhook",
     )
 
     # WebSocket configuration

--- a/src/main.py
+++ b/src/main.py
@@ -73,10 +73,12 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
         log_retention = os.getenv("LOG_RETENTION", "30 days")
         setup_logging(level=log_level, retention=log_retention)
 
-        print(f"🚀 Starting {settings.app_name} v{settings.app_version}")
-        print(f"📝 API Documentation: http://{settings.host}:{settings.port}/docs")
-        print(f"🔧 Debug mode: {settings.debug}")
-        print(f"📊 Log level: {log_level} | Retention: {log_retention}")
+        logger.info(f"🚀 Starting {settings.app_name} v{settings.app_version}")
+        logger.info(
+            f"📝 API Documentation: http://{settings.host}:{settings.port}/docs"
+        )
+        logger.info(f"🔧 Debug mode: {settings.debug}")
+        logger.info(f"📊 Log level: {log_level} | Retention: {log_retention}")
 
         sweep_service: BackgroundSweepService | None = None
 
@@ -90,13 +92,13 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 initialize_tts_service,
             )
 
-            print("\n📋 Loading service configurations...")
+            logger.info("📋 Loading service configurations...")
 
             if config_paths.get("tts_config_path"):
-                print(f"  - TTS config: {config_paths['tts_config_path']}")
+                logger.info(f"  - TTS config: {config_paths['tts_config_path']}")
                 initialize_tts_service(config_path=config_paths["tts_config_path"])
             else:
-                print("  - TTS config: Using default")
+                logger.info("  - TTS config: Using default")
                 initialize_tts_service()
 
             initialize_emotion_motion_mapper()
@@ -110,19 +112,19 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 initialize_mongodb_client()
 
             if config_paths.get("agent_config_path"):
-                print(f"  - Agent config: {config_paths['agent_config_path']}")
+                logger.info(f"  - Agent config: {config_paths['agent_config_path']}")
                 initialize_agent_service(
                     config_path=config_paths["agent_config_path"],
                 )
             else:
-                print("  - Agent config: Using default")
+                logger.info("  - Agent config: Using default")
                 initialize_agent_service()
 
             if config_paths.get("ltm_config_path"):
-                print(f"  - LTM config: {config_paths['ltm_config_path']}")
+                logger.info(f"  - LTM config: {config_paths['ltm_config_path']}")
                 initialize_ltm_service(config_path=config_paths["ltm_config_path"])
             else:
-                print("  - LTM config: Using default")
+                logger.info("  - LTM config: Using default")
                 initialize_ltm_service()
 
             # Async initialization: MCP tools + agent creation
@@ -202,10 +204,7 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 logger.exception("Failed to start background sweep service")
 
         except Exception as e:
-            print(f"⚠️  Failed to initialize services: {e}")
-            import traceback
-
-            traceback.print_exc()
+            logger.exception(f"⚠️  Failed to initialize services: {e}")
 
         return sweep_service
 
@@ -214,7 +213,7 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
     ) -> None:
         if sweep_service is not None:
             await sweep_service.stop()
-        print(f"👋 Shutting down {settings.app_name}")
+        logger.info(f"👋 Shutting down {settings.app_name}")
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -319,12 +318,9 @@ Example usage:
     # Load main configuration
     try:
         config_paths = load_main_config(args.yaml_file)
-        print(f"✅ Loaded configuration from: {args.yaml_file}")
+        logger.info(f"✅ Loaded configuration from: {args.yaml_file}")
     except Exception as e:
-        print(f"⚠️  Failed to load configuration from {args.yaml_file}: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"⚠️  Failed to load configuration from {args.yaml_file}: {e}")
         exit(1)
 
     # Export YAML_FILE so get_app() factory can pick it up on (re)import

--- a/src/services/agent_service/agent_factory.py
+++ b/src/services/agent_service/agent_factory.py
@@ -37,13 +37,22 @@ class AgentFactory:
 if __name__ == "__main__":
     import asyncio
 
-    load_dotenv()
-    # 1. 서비스 인스턴스 생성
+    import yaml
+    from loguru import logger
 
+    load_dotenv()
+
+    with open(
+        "./yaml_files/services/agent_service/openai_chat_agent.yml", encoding="utf-8"
+    ) as _f:
+        _cfg = yaml.safe_load(_f)
+    _openai_api_base = _cfg["llm_config"]["configs"]["openai_api_base"]
+
+    # 1. 서비스 인스턴스 생성
     agent_service = AgentFactory.get_agent_service(
         "openai_chat_agent",
         openai_api_key=os.getenv("LLM_API_KEY"),
-        openai_api_base="http://localhost:55120/v1",
+        openai_api_base=_openai_api_base,
         model_name="chat_model",
     )
 
@@ -55,6 +64,6 @@ if __name__ == "__main__":
     # 3. 서비스의 메인메서드 하나 호출하여 이미지 description 받기
     test = asyncio.run(main())
     if test:
-        print(f"성공! 에이전트 상태: {test}")
+        logger.info(f"성공! 에이전트 상태: {test}")
     else:
-        print("실패.")
+        logger.warning("실패.")

--- a/src/services/agent_service/tools/delegate/delegate_task.py
+++ b/src/services/agent_service/tools/delegate/delegate_task.py
@@ -1,6 +1,5 @@
 """DelegateTaskTool — async, uses ToolRuntime to read/write agent state."""
 
-import os
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -12,8 +11,6 @@ from langgraph.types import Command
 from src.services.agent_service.state import PendingTask
 from src.services.agent_service.tools.delegate.schemas import DelegateTaskInput
 
-NANOCLAW_URL = os.getenv("NANOCLAW_URL", "http://localhost:3000")
-BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 NANOCLAW_WEBHOOK_PATH = "/api/webhooks/fastapi"
 CALLBACK_PATH = "/v1/callback/nanoclaw"
 HTTP_TIMEOUT = 5.0
@@ -34,6 +31,8 @@ class DelegateTaskTool(BaseTool):
         raise NotImplementedError("Use _arun")
 
     async def _arun(self, task: str, runtime=None, **kwargs) -> Command:
+        from src.configs.settings import get_settings
+
         task_id = str(uuid4())
         now = datetime.now(UTC).isoformat()
 
@@ -51,17 +50,18 @@ class DelegateTaskTool(BaseTool):
         }
         pending.append(task_record)
 
+        _settings = get_settings()
         payload = {
             "task": task,
             "task_id": task_id,
-            "callback_url": f"{BACKEND_URL}{CALLBACK_PATH}/{task_id}",
+            "callback_url": f"{_settings.backend_url}{CALLBACK_PATH}/{task_id}",
         }
         msg_content = f"팀에 작업을 지시했습니다. (task_id: {task_id})"
 
         try:
             async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
                 await client.post(
-                    f"{NANOCLAW_URL}{NANOCLAW_WEBHOOK_PATH}", json=payload
+                    f"{_settings.nanoclaw_url}{NANOCLAW_WEBHOOK_PATH}", json=payload
                 )
         except Exception:
             msg_content = f"작업을 팀에 지시했지만, NanoClaw과의 통신에 실패했습니다. (task_id: {task_id})"

--- a/src/services/agent_service/utils/message_util.py
+++ b/src/services/agent_service/utils/message_util.py
@@ -6,6 +6,7 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+from loguru import logger
 
 
 def trim_messages(
@@ -61,7 +62,7 @@ def check_table_exists(conn, table_name, schema_name="public"):
         cursor.close()
         return exists
     except psycopg.Error as e:
-        print(f"Error checking table existence: {e}")
+        logger.error(f"Error checking table existence: {e}")
         return False
 
 

--- a/src/services/agent_service/utils/text_processor.py
+++ b/src/services/agent_service/utils/text_processor.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 import yaml
+from loguru import logger
 
 _DEFAULT_EMOJI_SET: frozenset[str] = frozenset(
     [
@@ -133,20 +134,18 @@ if __name__ == "__main__":
     # 예제 1: 영어 텍스트 (감정 태그)
     text1 = "I should check the user's mood first. (curious) So, how are you feeling today? *smiles warmly*"
     processed1 = processor.process_text(text1)
-    print("--- 예제 1 ---")
-    print(f"원본 텍스트: '{text1}'")
-    print(f"필터링된 텍스트: '{processed1.filtered_text}'")
-    print(f"감정 태그: {processed1.emotion_tag}")
-    print("-" * 20)
+    logger.debug("--- 예제 1 ---")
+    logger.debug(f"원본 텍스트: '{text1}'")
+    logger.debug(f"필터링된 텍스트: '{processed1.filtered_text}'")
+    logger.debug(f"감정 태그: {processed1.emotion_tag}")
 
     # 예제 2: 일본어 텍스트 (감정 태그 + 행동 지시)
     text2 = "(joyful)やったー！これで勝てる！ *ガッツポーズをする*"
     processed2 = processor.process_text(text2)
-    print("--- 예제 2 ---")
-    print(f"원본 텍스트: '{text2}'")
-    print(f"필터링된 텍스트: '{processed2.filtered_text}'")
-    print(f"감정 태그: {processed2.emotion_tag}")
-    print("-" * 20)
+    logger.debug("--- 예제 2 ---")
+    logger.debug(f"원본 텍스트: '{text2}'")
+    logger.debug(f"필터링된 텍스트: '{processed2.filtered_text}'")
+    logger.debug(f"감정 태그: {processed2.emotion_tag}")
 
     # TODO: 여러개의 감정태그를 처리할수 있도록 바꿔야할수도?
     # 예제 3: 톤 마커 및 웃음소리가 포함된 경우
@@ -154,8 +153,7 @@ if __name__ == "__main__":
         "(whispering) I think I found a clue... (laughing) Ha,ha,ha, this is hilarious!"
     )
     processed3 = processor.process_text(text3)
-    print("--- 예제 3 ---")
-    print(f"원본 텍스트: '{text3}'")
-    print(f"필터링된 텍스트: '{processed3.filtered_text}'")
-    print(f"감정 태그: {processed3.emotion_tag}")
-    print("-" * 20)
+    logger.debug("--- 예제 3 ---")
+    logger.debug(f"원본 텍스트: '{text3}'")
+    logger.debug(f"필터링된 텍스트: '{processed3.filtered_text}'")
+    logger.debug(f"감정 태그: {processed3.emotion_tag}")

--- a/src/services/ltm_service/ltm_factory.py
+++ b/src/services/ltm_service/ltm_factory.py
@@ -1,4 +1,5 @@
 from dotenv import load_dotenv
+from loguru import logger
 
 from src.services.ltm_service.service import LTMService
 
@@ -37,7 +38,6 @@ if __name__ == "__main__":
     from src.configs.ltm import Mem0LongTermMemoryConfig
 
     # 1. 서비스 인스턴스 생성
-    # print(memory_config.model_dump())
     with open("./yaml_files/services/ltm_service/mem0.yml", encoding="utf-8") as f:
         config = yaml.safe_load(f)
     memory_config = Mem0LongTermMemoryConfig(**config["ltm_config"]["configs"])
@@ -47,6 +47,6 @@ if __name__ == "__main__":
     healthy, message = ltm_service.is_healthy()
 
     if healthy:
-        print("LTM Service is healthy:", message)
+        logger.info(f"LTM Service is healthy: {message}")
     else:
-        print("LTM Service is not healthy:", message)
+        logger.error(f"LTM Service is not healthy: {message}")

--- a/src/services/tts_service/tts_factory.py
+++ b/src/services/tts_service/tts_factory.py
@@ -1,3 +1,5 @@
+from loguru import logger
+
 from src.services.tts_service.service import TTSService
 
 
@@ -35,12 +37,16 @@ class TTSFactory:
 
 
 if __name__ == "__main__":
-    IRODORI_URL = "http://localhost:8000"
+    import yaml
+
+    with open("./yaml_files/services/tts_service/irodori.yml", encoding="utf-8") as _f:
+        _cfg = yaml.safe_load(_f)
+    IRODORI_URL = _cfg["tts_config"]["configs"]["base_url"]
 
     tts_service = TTSFactory.get_tts_engine("irodori", base_url=IRODORI_URL)
     llm_output_text = "😊That's wonderful news! I'm so happy for you!"
 
-    print("--- 'bytes' 포맷으로 오디오 생성 시도 ---")
+    logger.info("--- 'bytes' 포맷으로 오디오 생성 시도 ---")
     audio_data = tts_service.generate_speech(
         text=llm_output_text,
         reference_id="ナツメ",
@@ -48,6 +54,6 @@ if __name__ == "__main__":
     )
 
     if audio_data and isinstance(audio_data, bytes):
-        print(f"성공! 오디오 데이터 수신 (크기: {len(audio_data)} bytes)")
+        logger.info(f"성공! 오디오 데이터 수신 (크기: {len(audio_data)} bytes)")
     else:
-        print("실패.")
+        logger.warning("실패.")

--- a/src/services/tts_service/vllm_omni.py
+++ b/src/services/tts_service/vllm_omni.py
@@ -17,7 +17,7 @@ class VLLMOmniTTSService(TTSService):
 
     def __init__(
         self,
-        base_url: str = "http://127.0.0.1:5517",
+        base_url: str,
         api_key: str = "token-abc123",
         model: str = "chat_model",
         task_type: str = "Base",
@@ -261,7 +261,7 @@ if __name__ == "__main__":
     llm_output_text = "That's wonderful news! I'm so happy for you!"
 
     # 3. 서비스의 메인 메서드 하나만 호출하여 오디오 데이터 받기
-    print("--- 'bytes' 포맷으로 오디오 생성 시도 ---")
+    logger.info("--- 'bytes' 포맷으로 오디오 생성 시도 ---")
     audio_data = tts_service.generate_speech(
         text=llm_output_text,
         reference_id="ナツメ",
@@ -269,11 +269,11 @@ if __name__ == "__main__":
     )
 
     if audio_data and isinstance(audio_data, bytes):
-        print(f"성공! 오디오 데이터 수신 (크기: {len(audio_data)} bytes)")
+        logger.info(f"성공! 오디오 데이터 수신 (크기: {len(audio_data)} bytes)")
     else:
-        print("실패.")
+        logger.warning("실패.")
 
-    print("\n--- 'file' 포맷으로 오디오 생성 시도 ---")
+    logger.info("\n--- 'file' 포맷으로 오디오 생성 시도 ---")
     file_audio = tts_service.generate_speech(
         text=llm_output_text,
         output_format="file",
@@ -283,11 +283,11 @@ if __name__ == "__main__":
     )
 
     if file_audio:
-        print("성공! 파일로 저장되었습니다: output.wav")
+        logger.info("성공! 파일로 저장되었습니다: output.wav")
     else:
-        print("실패.")
+        logger.warning("실패.")
 
-    print("\n--- 'file' 포맷으로 오디오 생성 시도 ---")
+    logger.info("\n--- 'file' 포맷으로 오디오 생성 시도 ---")
     file_audio = tts_service.generate_speech(
         text=llm_output_text,
         output_format="file",
@@ -297,8 +297,8 @@ if __name__ == "__main__":
     )
 
     if file_audio:
-        print("성공! 파일로 저장되었습니다: output.mp3")
+        logger.info("성공! 파일로 저장되었습니다: output.mp3")
     else:
-        print("실패.")
+        logger.warning("실패.")
 
-    print(tts_service._ref_cache)
+    logger.debug(f"ref_cache: {tts_service._ref_cache}")

--- a/src/services/websocket_service/manager/disconnect_handler.py
+++ b/src/services/websocket_service/manager/disconnect_handler.py
@@ -1,6 +1,5 @@
 """Disconnect-time delegate trigger for knowledge summary."""
 
-import os
 from collections.abc import Awaitable, Callable
 
 from langchain_core.messages import HumanMessage as HMsg
@@ -8,7 +7,6 @@ from loguru import logger
 
 MIN_TURNS_FOR_SUMMARY: int = 3
 STM_INLINE_MAX_TURNS: int = 30
-BACKEND_URL: str = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 
 def build_delegate_payload(
@@ -30,7 +28,11 @@ def build_delegate_payload(
     if human_count < STM_INLINE_MAX_TURNS:
         base["stm_messages"] = convert_to_openai_messages(messages)
     else:
-        base["stm_fetch_url"] = f"{BACKEND_URL}/v1/stm/{session_id}/messages"
+        from src.configs.settings import get_settings
+
+        base["stm_fetch_url"] = (
+            f"{get_settings().backend_url}/v1/stm/{session_id}/messages"
+        )
     return base
 
 

--- a/tests/structural/test_architecture.py
+++ b/tests/structural/test_architecture.py
@@ -243,26 +243,9 @@ class TestFileSizeLimits:
 class TestCodeConventions:
     """Enforce conventions that static linters cannot check."""
 
-    # main.py: intentional startup messages — TODO: replace with structured logger
-    # service files: debugging artifacts — TODO: replace with logger.debug()
-    _KNOWN_PRINT_FILES: set[str] = {
-        "main.py",
-        "services/agent_service/agent_factory.py",
-        "services/agent_service/utils/message_util.py",
-        "services/agent_service/utils/text_processor.py",
-        "services/ltm_service/ltm_factory.py",
-        "services/tts_service/tts_factory.py",
-        "services/tts_service/vllm_omni.py",
-    }
+    _KNOWN_PRINT_FILES: set[str] = set()
 
-    # Factory defaults and delegate URLs — TODO: move to YAML config
-    _KNOWN_LOCALHOST_FILES: set[str] = {
-        "services/tts_service/vllm_omni.py",
-        "services/tts_service/tts_factory.py",
-        "services/agent_service/agent_factory.py",
-        "services/agent_service/tools/delegate/delegate_task.py",
-        "services/websocket_service/manager/disconnect_handler.py",
-    }
+    _KNOWN_LOCALHOST_FILES: set[str] = set()
 
     def test_no_bare_print_in_src(self):
         """


### PR DESCRIPTION
## Summary

**QA-1 (GP-4 Critical) — Hardcoded URL removal:**
- `src/configs/settings.py`: added `backend_url` + `nanoclaw_url` fields to `Settings`, defaulting to `BACKEND_URL` / `NANOCLAW_URL` env vars
- `disconnect_handler.py`: replaced module-level `os.getenv("BACKEND_URL", ...)` with lazy `get_settings().backend_url`
- `delegate_task.py`: replaced module-level `NANOCLAW_URL` / `BACKEND_URL` constants with lazy `get_settings()` calls inside `_arun`
- `vllm_omni.py`: removed hardcoded `"http://127.0.0.1:5517"` default from `__init__` — `base_url` is now required (factory always passes it from YAML)
- `tts_factory.py` + `agent_factory.py`: `__main__` example blocks now load URLs from their respective YAML configs instead of hardcoding

**QA-2 (GP-3 Major) — Bare print removal:**
- `main.py`, `ltm_factory.py`, `vllm_omni.py`, `tts_factory.py`, `agent_factory.py`, `message_util.py`, `text_processor.py` — all `print()` calls replaced with `logger.info/warning/error/exception/debug`

**Structural tests:** cleared `_KNOWN_PRINT_FILES` and `_KNOWN_LOCALHOST_FILES` known-debt sets in `tests/structural/test_architecture.py`

## Test Coverage

All new code paths are config/logging wiring — no new business logic. Structural tests (9/9 pass) validate GP-3 and GP-4 compliance via AST analysis.

## Pre-Landing Review

No issues found. All changes are mechanical replacements with no new logic.

## Design Review

No frontend files changed — design review skipped.

## Note on e2e.sh

`bash backend/scripts/e2e.sh` fails due to pre-existing LLM API errors (`System message must be at the beginning`) unrelated to this PR. The same failures exist on `master` before this change. Confirmed by running e2e on master: identical failure pattern.

## Test plan
- [x] `sh scripts/lint.sh` — 9/9 structural tests pass, ruff + black clean
- [x] `grep -rn 'print(' src/` → GP-3: CLEAN
- [x] `grep -rn 'localhost\|127\.0\.0\.1' src/ | grep -v config | grep -v test` → GP-4: CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)