### PR TITLE
fix: remove redundant {e} from logger.exception and use pathlib for YAML paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to DesktopMatePlus Backend will be documented in this file.
 
+## [2.4.2] - 2026-04-04
+
+### Fixed
+
+- Removed redundant `{e}` interpolation from two `logger.exception()` calls in `src/main.py` — `logger.exception` already captures and appends the exception automatically
+- Replaced hardcoded relative paths (`"./yaml_files/..."`) with `pathlib.Path(__file__).resolve().parents[3] / ...` in `agent_factory.py` and `tts_factory.py` `__main__` blocks — fixes CWD-dependent path resolution
+
 ## [2.4.1] - 2026-04-03
 
 ### Fixed

--- a/src/main.py
+++ b/src/main.py
@@ -203,8 +203,8 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
             except Exception:
                 logger.exception("Failed to start background sweep service")
 
-        except Exception as e:
-            logger.exception(f"⚠️  Failed to initialize services: {e}")
+        except Exception:
+            logger.exception("⚠️  Failed to initialize services")
 
         return sweep_service
 
@@ -319,8 +319,8 @@ Example usage:
     try:
         config_paths = load_main_config(args.yaml_file)
         logger.info(f"✅ Loaded configuration from: {args.yaml_file}")
-    except Exception as e:
-        logger.exception(f"⚠️  Failed to load configuration from {args.yaml_file}: {e}")
+    except Exception:
+        logger.exception(f"⚠️  Failed to load configuration from {args.yaml_file}")
         exit(1)
 
     # Export YAML_FILE so get_app() factory can pick it up on (re)import

--- a/src/services/agent_service/agent_factory.py
+++ b/src/services/agent_service/agent_factory.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -42,9 +43,14 @@ if __name__ == "__main__":
 
     load_dotenv()
 
-    with open(
-        "./yaml_files/services/agent_service/openai_chat_agent.yml", encoding="utf-8"
-    ) as _f:
+    _yaml_path = (
+        Path(__file__).resolve().parents[3]
+        / "yaml_files"
+        / "services"
+        / "agent_service"
+        / "openai_chat_agent.yml"
+    )
+    with open(_yaml_path, encoding="utf-8") as _f:
         _cfg = yaml.safe_load(_f)
     _openai_api_base = _cfg["llm_config"]["configs"]["openai_api_base"]
 

--- a/src/services/tts_service/tts_factory.py
+++ b/src/services/tts_service/tts_factory.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from loguru import logger
 
 from src.services.tts_service.service import TTSService
@@ -39,7 +41,14 @@ class TTSFactory:
 if __name__ == "__main__":
     import yaml
 
-    with open("./yaml_files/services/tts_service/irodori.yml", encoding="utf-8") as _f:
+    _yaml_path = (
+        Path(__file__).resolve().parents[3]
+        / "yaml_files"
+        / "services"
+        / "tts_service"
+        / "irodori.yml"
+    )
+    with open(_yaml_path, encoding="utf-8") as _f:
         _cfg = yaml.safe_load(_f)
     IRODORI_URL = _cfg["tts_config"]["configs"]["base_url"]
 


### PR DESCRIPTION
## Summary

Post-merge sweep fix for PR #9 Gemini bot review comments (4 valid issues):

**logger.exception redundancy (`src/main.py`)**
- Line 207: `logger.exception(f"⚠️  Failed to initialize services: {e}")` → removed `{e}` and bare `except Exception as e:` → `except Exception:`
- Line 323: `logger.exception(f"⚠️  Failed to load configuration from ...: {e}")` → removed `{e}`, same pattern

`logger.exception()` automatically captures and appends the current exception (including traceback) — interpolating `{e}` duplicates it in the log output.

**Hardcoded relative YAML paths → pathlib**
- `src/services/agent_service/agent_factory.py`: `"./yaml_files/..."` → `Path(__file__).resolve().parents[3] / "yaml_files" / ...`
- `src/services/tts_service/tts_factory.py`: same pattern

`"./yaml_files/..."` resolves relative to CWD, not the source file's location. Using `pathlib.Path(__file__)` makes the path correct regardless of where the script is invoked from.

## Pre-Landing Review

No structural issues. Changes are purely mechanical — logging semantics and path resolution. No new logic.

## Test Coverage

All 9 structural tests pass (`sh scripts/lint.sh`). No new code paths — the `__main__` blocks are not exercised by the test suite (they are manual smoke test utilities only).

## Test plan
- [x] `sh scripts/lint.sh` — ruff + black clean, 9/9 structural tests pass
- [x] `git diff master...HEAD` — 3 files, 23 lines, no functional logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)