### PR TITLE
feat: add POST /v1/tts/speak endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to DesktopMatePlus Backend will be documented in this file.
 
+## [2.4.3] - 2026-04-04
+
+### Added
+
+- `POST /v1/tts/speak` endpoint — accepts `{ "text": "..." }` and returns `{ "audio_base64": "..." }` using the active TTS service. Returns 503 if service is unavailable or synthesis fails (including non-string return values like `False`).
+
 ## [2.4.2] - 2026-04-04
 
 ### Fixed

--- a/src/api/routes/tts.py
+++ b/src/api/routes/tts.py
@@ -1,8 +1,10 @@
 """TTS API routes."""
 
+from asyncio import to_thread
+
 from fastapi import APIRouter, HTTPException, status
 
-from src.models.tts import VoicesResponse
+from src.models.tts import SpeakRequest, SpeakResponse, VoicesResponse
 from src.services import get_tts_service
 
 router = APIRouter(prefix="/v1/tts", tags=["TTS"])
@@ -25,6 +27,38 @@ async def list_voices() -> VoicesResponse:
             detail="TTS service not available",
         )
     return VoicesResponse(voices=tts_service.list_voices())
+
+
+@router.post(
+    "/speak",
+    summary="Synthesize speech from text",
+    response_model=SpeakResponse,
+    status_code=status.HTTP_200_OK,
+    responses={
+        503: {"description": "TTS service not initialized or synthesis failed"},
+        422: {"description": "Invalid request body"},
+    },
+)
+async def speak(body: SpeakRequest) -> SpeakResponse:
+    tts_service = get_tts_service()
+    if tts_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="TTS service not available",
+        )
+    audio_base64 = await to_thread(
+        tts_service.generate_speech,
+        body.text,
+        None,
+        "base64",
+        audio_format="wav",
+    )
+    if not isinstance(audio_base64, str):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="TTS synthesis failed",
+        )
+    return SpeakResponse(audio_base64=audio_base64)
 
 
 __all__ = ["router"]

--- a/src/models/tts.py
+++ b/src/models/tts.py
@@ -9,4 +9,16 @@ class VoicesResponse(BaseModel):
     voices: list[str]
 
 
-__all__ = ["VoicesResponse"]
+class SpeakRequest(BaseModel):
+    """Request model for the speak endpoint."""
+
+    text: str
+
+
+class SpeakResponse(BaseModel):
+    """Response model for the speak endpoint."""
+
+    audio_base64: str
+
+
+__all__ = ["SpeakRequest", "SpeakResponse", "VoicesResponse"]

--- a/tests/api/test_tts_speak_api.py
+++ b/tests/api/test_tts_speak_api.py
@@ -1,0 +1,72 @@
+"""Tests for POST /v1/tts/speak endpoint."""
+
+from unittest.mock import Mock, patch
+
+from fastapi import status
+
+
+class TestSpeakEndpoint:
+    @patch("src.api.routes.tts.get_tts_service")
+    def test_returns_200_with_audio_base64(self, mock_get_tts, client):
+        mock_tts = Mock()
+        mock_tts.generate_speech.return_value = "base64encodedaudio=="
+        mock_get_tts.return_value = mock_tts
+
+        response = client.post("/v1/tts/speak", json={"text": "hello world"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["audio_base64"] == "base64encodedaudio=="
+
+    @patch("src.api.routes.tts.get_tts_service")
+    def test_calls_generate_speech_with_base64_format(self, mock_get_tts, client):
+        mock_tts = Mock()
+        mock_tts.generate_speech.return_value = "audio=="
+        mock_get_tts.return_value = mock_tts
+
+        client.post("/v1/tts/speak", json={"text": "test text"})
+
+        mock_tts.generate_speech.assert_called_once_with(
+            "test text",
+            None,
+            "base64",
+            audio_format="wav",
+        )
+
+    @patch("src.api.routes.tts.get_tts_service")
+    def test_returns_503_when_service_none(self, mock_get_tts, client):
+        mock_get_tts.return_value = None
+
+        response = client.post("/v1/tts/speak", json={"text": "hello"})
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "TTS service not available" in response.json()["detail"]
+
+    @patch("src.api.routes.tts.get_tts_service")
+    def test_returns_503_when_generate_speech_returns_none(self, mock_get_tts, client):
+        mock_tts = Mock()
+        mock_tts.generate_speech.return_value = None
+        mock_get_tts.return_value = mock_tts
+
+        response = client.post("/v1/tts/speak", json={"text": "hello"})
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "TTS synthesis failed" in response.json()["detail"]
+
+    @patch("src.api.routes.tts.get_tts_service")
+    def test_returns_503_when_generate_speech_returns_false(self, mock_get_tts, client):
+        mock_tts = Mock()
+        mock_tts.generate_speech.return_value = False
+        mock_get_tts.return_value = mock_tts
+
+        response = client.post("/v1/tts/speak", json={"text": "hello"})
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "TTS synthesis failed" in response.json()["detail"]
+
+    def test_returns_422_when_text_missing(self, client):
+        response = client.post("/v1/tts/speak", json={})
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    def test_returns_422_when_body_missing(self, client):
+        response = client.post("/v1/tts/speak")
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT


### PR DESCRIPTION
## Summary

- **New endpoint** `POST /v1/tts/speak` in `src/api/routes/tts.py` — accepts `{ "text": "..." }`, returns `{ "audio_base64": "..." }` as WAV audio in base64 encoding
- **New Pydantic models** `SpeakRequest` / `SpeakResponse` in `src/models/tts.py`
- Delegates to `TTSService.generate_speech()` via `asyncio.to_thread` (correct async wrapping of blocking I/O)
- Returns 503 if service unavailable, not initialized, or synthesis fails (including `None` and `False` return values)

## Test Coverage

All 7 new code paths tested:
- 200 happy path with audio_base64
- generate_speech called with correct args (base64, wav)
- 503 when service is None
- 503 when generate_speech returns None
- 503 when generate_speech returns False (edge case — non-str guard via `isinstance`)
- 422 when text missing
- 422 when body missing

Tests: 0 → 1 new file (+7 tests)

## Pre-Landing Review

Pre-Landing Review: 1 informational auto-fixed
- `[AUTO-FIXED] src/api/routes/tts.py:56` — Changed `is None` guard to `isinstance(audio_base64, str)` to cleanly reject `None`, `False`, or `bytes` return values from `generate_speech`

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Greptile Review

No Greptile comments.

## Plan Completion

- [DONE] `POST /v1/tts/speak` endpoint — `src/api/routes/tts.py` (+36 lines)
- [DONE] Request/response Pydantic models — `src/models/tts.py` (+14 lines)
- [DONE] Pytest TDD — `tests/api/test_tts_speak_api.py` (+72 lines, 7 tests)

COMPLETION: 3/3 DONE

## TODOS

No TODO items completed in this PR.

## Test plan
- [x] i already confirm E2E test is passed (pre-existing failures in Phase 4/5 are unrelated to TTS — agent LLM "System message must be at the beginning" error pre-dates this branch)
- [x] 7 new TTS speak tests pass
- [x] Existing 5 TTS voices tests pass
- [x] lint.sh clean (ruff + black + structural tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)