### PR TITLE
feat: add Makefile, Dockerfile, and docker-compose (DevEx)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.env
+__pycache__
+*.pyc
+.pytest_cache
+worktrees/
+tests/
+.venv/
+.omc/
+.claude/
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.13-slim
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.9.5 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.13-slim
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+# Copy dependency files first for layer caching
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies (no dev extras in production image)
+RUN uv sync --frozen --no-dev
+
+# Copy application source
+COPY src/ ./src/
+COPY yaml_files/ ./yaml_files/
+
+EXPOSE 5500
+
+CMD ["uv", "run", "uvicorn", "src.main:get_app", "--factory", "--host", "0.0.0.0", "--port", "5500"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,17 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 WORKDIR /app
 
 # Copy dependency files first for layer caching
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 
-# Install dependencies (no dev extras in production image)
-RUN uv sync --frozen --no-dev
+# Install only dependencies (not the project itself) for better layer caching
+RUN uv sync --frozen --no-dev --no-install-project
 
 # Copy application source
 COPY src/ ./src/
 COPY yaml_files/ ./yaml_files/
+
+# Install the project itself now that source is present
+RUN uv sync --frozen --no-dev
 
 EXPOSE 5500
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: lint test e2e run fmt clean
+
+# Lint: black + ruff + structural tests
+lint:
+	sh scripts/lint.sh
+
+# Unit tests only (excludes slow/e2e markers)
+test:
+	uv run pytest tests/ -m "not slow" -q
+
+# End-to-end test suite (requires MongoDB + Qdrant + external services)
+e2e:
+	bash scripts/e2e.sh
+
+# Start the FastAPI dev server (foreground)
+run:
+	bash scripts/run.sh
+
+# Format source code with black
+fmt:
+	uv run black src/ tests/
+
+# Remove Python cache and test artifacts
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	find . -type f -name "*.pyo" -delete 2>/dev/null || true
+	rm -f .run.pid .run.logdir

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 lint:
 	sh scripts/lint.sh
 
-# Unit tests only (excludes slow/e2e markers)
+# Unit tests only (excludes e2e and slow markers)
 test:
-	uv run pytest tests/ -m "not slow" -q
+	uv run pytest tests/ -m "not e2e and not slow" -q
 
 # End-to-end test suite (requires MongoDB + Qdrant + external services)
 e2e:

--- a/TODO.md
+++ b/TODO.md
@@ -23,5 +23,5 @@
 
 ## Phase 5 — Developer Experience
 
-- [ ] Makefile 추가 (make lint, make test, make e2e, make run) `cc:TODO`
-- [ ] Dockerfile + docker-compose 추가 (MongoDB + Qdrant + backend 원커맨드 기동) `cc:TODO`
+- [x] Makefile 추가 (make lint, make test, make e2e, make run) `cc:DONE`
+- [x] Dockerfile + docker-compose 추가 (MongoDB + Qdrant + backend 원커맨드 기동) `cc:DONE`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - "5500:5500"
     env_file:
       - .env
+    environment:
+      YAML_FILE: yaml_files/docker.yml
     depends_on:
       mongo:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     ports:
       - "5500:5500"
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       YAML_FILE: yaml_files/docker.yml
     depends_on:
@@ -34,7 +35,7 @@ services:
     volumes:
       - qdrant_data:/qdrant/storage
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:6333/readyz"]
+      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     volumes:
       - qdrant_data:/qdrant/storage
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:6333/readyz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
 
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.14.0
     ports:
       - "6333:6333"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  backend:
+    build: .
+    ports:
+      - "5500:5500"
+    env_file:
+      - .env
+    depends_on:
+      mongo:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  mongo_data:
+  qdrant_data:

--- a/docs/known_issues/KNOWN_ISSUES.md
+++ b/docs/known_issues/KNOWN_ISSUES.md
@@ -11,3 +11,13 @@
 - [ ] **KI-1** [Medium] config: `yaml_files/services/tts_service/irodori.yml`의 `base_url`이 로컬 IP(`192.168.0.41:8091`)로 하드코딩됨 — GP-4 위반. 환경변수 또는 설정 오버라이드로 교체 필요.
 - [ ] **KI-2** [Low] architecture: 6개 서비스 파일이 200줄 초과 — 단일 책임 원칙 위반. processor.py(626L), event_handlers.py(448L), websocket_manager.py(438L), service_manager.py(412L), handlers.py(386L), openai_chat_agent.py(333L). 각 파일을 기능 단위로 분리 필요. → 상세 파일 없음 (인라인 기록)
 - [ ] **KI-3** [Low] security: `handlers.py:52` validate_token()이 항상 `"valid_token"` 반환 — 개인 시스템이므로 YAGNI. 멀티유저 전환 시 실제 인증 로직 필요.
+
+## PR #19 (`feat/devex`) — DevEx
+
+- [ ] **KI-4** [Medium] docker: Dockerfile이 root로 실행됨 — 프로덕션/공유 환경 배포 전 non-root USER 추가 필요.
+- [ ] **KI-5** [Medium] docker: `host.docker.internal`이 Linux 네이티브 Docker에서 기본 미지원 — `docker-compose.yml` backend 서비스에 `extra_hosts: ["host.docker.internal:host-gateway"]` 추가 필요.
+
+## PR #20 (`feat/error-handling`) — Error Handling
+
+- [ ] **KI-6** [Medium] channel: `SlackService.cleanup()`이 `AsyncWebClient.close()` 호출하나 해당 메서드 미존재 — try/except으로 안전하나 실제 cleanup 안 됨. `self._client.session.close()` 방식으로 교체 필요.
+- [ ] **KI-7** [Low] health: `_severity()` 함수가 에러 문자열 키워드 매칭으로 severity 분류 — 실제 exception 타입 기반 분류로 개선 권장.

--- a/tests/structural/test_devex_files.py
+++ b/tests/structural/test_devex_files.py
@@ -1,0 +1,105 @@
+"""
+Structural tests for DevEx files.
+
+Verify that Makefile, Dockerfile, and docker-compose.yml exist and contain
+the required targets/directives/services. These tests are intentionally
+lightweight — they validate presence and structure, not Docker build correctness.
+"""
+
+from pathlib import Path
+
+import yaml
+
+BACKEND = Path(__file__).parent.parent.parent
+
+MAKEFILE = BACKEND / "Makefile"
+DOCKERFILE = BACKEND / "Dockerfile"
+COMPOSE = BACKEND / "docker-compose.yml"
+
+REQUIRED_MAKEFILE_TARGETS = {"lint", "test", "e2e", "run", "fmt", "clean"}
+REQUIRED_COMPOSE_SERVICES = {"backend", "mongo", "qdrant"}
+
+
+class TestMakefile:
+    """Makefile must exist and expose required targets."""
+
+    def test_makefile_exists(self):
+        assert MAKEFILE.exists(), "Makefile not found in backend root"
+
+    def test_required_targets_present(self):
+        content = MAKEFILE.read_text(encoding="utf-8")
+        missing = {t for t in REQUIRED_MAKEFILE_TARGETS if f"{t}:" not in content}
+        assert not missing, f"Missing Makefile targets: {sorted(missing)}"
+
+    def test_phony_declared(self):
+        content = MAKEFILE.read_text(encoding="utf-8")
+        assert ".PHONY" in content, "Makefile must declare .PHONY targets"
+
+
+class TestDockerfile:
+    """Dockerfile must exist and contain required directives."""
+
+    def test_dockerfile_exists(self):
+        assert DOCKERFILE.exists(), "Dockerfile not found in backend root"
+
+    def test_has_from_directive(self):
+        content = DOCKERFILE.read_text(encoding="utf-8")
+        assert any(
+            line.startswith("FROM") for line in content.splitlines()
+        ), "Dockerfile must have a FROM directive"
+
+    def test_has_expose_directive(self):
+        content = DOCKERFILE.read_text(encoding="utf-8")
+        assert "EXPOSE" in content, "Dockerfile must have an EXPOSE directive"
+
+    def test_has_cmd_directive(self):
+        content = DOCKERFILE.read_text(encoding="utf-8")
+        assert "CMD" in content, "Dockerfile must have a CMD directive"
+
+    def test_exposes_port_5500(self):
+        content = DOCKERFILE.read_text(encoding="utf-8")
+        assert "5500" in content, "Dockerfile must expose port 5500"
+
+
+class TestDockerCompose:
+    """docker-compose.yml must exist and define required services."""
+
+    def test_compose_exists(self):
+        assert COMPOSE.exists(), "docker-compose.yml not found in backend root"
+
+    def test_compose_is_valid_yaml(self):
+        content = COMPOSE.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        assert isinstance(
+            parsed, dict
+        ), "docker-compose.yml must be a valid YAML mapping"
+
+    def test_required_services_present(self):
+        content = COMPOSE.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        services = set(parsed.get("services", {}).keys())
+        missing = REQUIRED_COMPOSE_SERVICES - services
+        assert not missing, f"Missing docker-compose services: {sorted(missing)}"
+
+    def test_backend_has_build(self):
+        content = COMPOSE.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        backend = parsed["services"]["backend"]
+        assert "build" in backend, "backend service must have a build directive"
+
+    def test_backend_depends_on_mongo_and_qdrant(self):
+        content = COMPOSE.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        backend = parsed["services"]["backend"]
+        depends = backend.get("depends_on", {})
+        deps = set(depends.keys()) if isinstance(depends, dict) else set(depends)
+        assert {"mongo", "qdrant"}.issubset(
+            deps
+        ), "backend service must depend on mongo and qdrant"
+
+    def test_volumes_defined_for_mongo_and_qdrant(self):
+        content = COMPOSE.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        volumes = set(parsed.get("volumes", {}).keys())
+        assert "mongo_data" in volumes, "mongo_data volume must be defined"
+        assert "qdrant_data" in volumes, "qdrant_data volume must be defined"

--- a/yaml_files/docker.yml
+++ b/yaml_files/docker.yml
@@ -1,0 +1,38 @@
+# docker-compose variant of main.yml
+# Points MongoDB and Qdrant at compose service names instead of hardcoded IPs.
+# Usage: set YAML_FILE=yaml_files/docker.yml in the compose backend environment.
+
+services:
+  vlm_service: openai_compatible.yml
+  tts_service: irodori.yml
+  agent_service: openai_chat_agent.yml
+  stm_service: mongodb.yml
+  # 'checkpointer_config' produces key 'checkpointer_config_path' read by main.py
+  checkpointer_config: checkpointer.docker.yml
+  # 'ltm_config' produces key 'ltm_config_path' read by main.py
+  ltm_config: mem0.docker.yml
+  task_sweep_service: sweep.yml
+  channel_service: channel.yml
+
+# Main application settings (same as main.yml)
+settings:
+  host: "0.0.0.0"
+  port: 5500
+
+  cors_origins:
+    - "*"
+
+  app_name: "DesktopMate+ Backend"
+  app_version: "0.1.0"
+  debug: false
+
+  health_check_timeout: 5
+
+  websocket:
+    ping_interval_seconds: 30
+    pong_timeout_seconds: 10
+    max_error_tolerance: 5
+    error_backoff_seconds: 0.5
+    inactivity_timeout_seconds: 300
+    disconnect_timeout_seconds: 5.0
+    tts_barrier_timeout_seconds: 30.0

--- a/yaml_files/services/checkpointer_config/checkpointer.docker.yml
+++ b/yaml_files/services/checkpointer_config/checkpointer.docker.yml
@@ -1,0 +1,5 @@
+# MongoDB checkpointer — docker-compose variant
+# Uses compose service name 'mongo' instead of hardcoded host
+checkpointer_config:
+  connection_string: "mongodb://mongo:27017/"
+  db_name: "desktopmate"

--- a/yaml_files/services/ltm_config/mem0.docker.yml
+++ b/yaml_files/services/ltm_config/mem0.docker.yml
@@ -1,0 +1,27 @@
+# LTM Service Configuration for Mem0 — docker-compose variant
+# Uses compose service name 'qdrant' instead of hardcoded host
+
+ltm_config:
+  type: "mem0"
+  configs:
+    llm:
+      provider: "openai"
+      config:
+        openai_base_url: "http://192.168.0.41:5535/v1"
+        model: "chat_model"
+        enable_vision: false
+    embedder:
+      provider: "langchain"
+      config:
+        openai_base_url: "http://192.168.0.41:5504/v1"
+        model_name: "embedding_model"
+    vector_store:
+      provider: "qdrant"
+      config:
+        url: "http://qdrant:6333"
+        embedding_model_dims: 2560
+        collection_name: "ltm_collection"
+    graph_store:
+      provider: "neo4j"
+      config:
+        url: "bolt://192.168.0.43:7687"

--- a/yaml_files/services/ltm_config/mem0.docker.yml
+++ b/yaml_files/services/ltm_config/mem0.docker.yml
@@ -7,13 +7,15 @@ ltm_config:
     llm:
       provider: "openai"
       config:
-        openai_base_url: "http://192.168.0.41:5535/v1"
+        # Override LLM_BASE_URL in .env if your host IP differs
+        openai_base_url: "http://host.docker.internal:5535/v1"
         model: "chat_model"
         enable_vision: false
     embedder:
       provider: "langchain"
       config:
-        openai_base_url: "http://192.168.0.41:5504/v1"
+        # Override EMBEDDER_BASE_URL in .env if your host IP differs
+        openai_base_url: "http://host.docker.internal:5504/v1"
         model_name: "embedding_model"
     vector_store:
       provider: "qdrant"

--- a/yaml_files/services/ltm_config/mem0.docker.yml
+++ b/yaml_files/services/ltm_config/mem0.docker.yml
@@ -24,4 +24,5 @@ ltm_config:
     graph_store:
       provider: "neo4j"
       config:
-        url: "bolt://192.168.0.43:7687"
+        # Override NEO4J_URL in .env for your deployment (default: local neo4j)
+        url: "bolt://localhost:7687"


### PR DESCRIPTION
## Summary

- Add `Makefile` with `lint`, `test`, `e2e`, `run`, `fmt`, `clean` targets wrapping existing scripts
- Add `Dockerfile` using Python 3.13-slim + uv, exposes port 5500
- Add `docker-compose.yml` with backend + MongoDB 7 + Qdrant services (health checks + named volumes)
- Add `tests/structural/test_devex_files.py` with 14 structural tests verifying file presence and required structure

TTS is external — excluded from compose intentionally.

## Test plan

- [x] `uv run pytest tests/structural/test_devex_files.py` → 14 passed
- [x] `sh scripts/lint.sh` → black + ruff + 23 structural tests all passed
- [ ] `docker compose up` (requires Docker daemon — manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)