### PR TITLE
feat: add builtin tools with YAML-driven tool registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
     "slack-sdk>=3.34.0",
     "langgraph-checkpoint-mongodb>=0.3.1",
     "basedpyright>=1.39.0",
+    "langchain-community>=0.4.1",
+    "duckduckgo-search>=8.1.1",
+    "ddgs>=9.13.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     "langgraph-checkpoint-mongodb>=0.3.1",
     "basedpyright>=1.39.0",
     "langchain-community>=0.4.1",
-    "duckduckgo-search>=8.1.1",
     "ddgs>=9.13.0",
 ]
 

--- a/src/configs/agent/openai_chat_agent.py
+++ b/src/configs/agent/openai_chat_agent.py
@@ -31,3 +31,7 @@ class OpenAIChatAgentConfig(BaseModel):
         default=False,
         description="Whether the agent supports image inputs in messages",
     )
+    tool_config: dict | None = Field(
+        default=None,
+        description="Tool registry configuration for builtin tools (filesystem, shell, web_search)",
+    )

--- a/src/configs/agent/openai_chat_agent.py
+++ b/src/configs/agent/openai_chat_agent.py
@@ -2,7 +2,7 @@
 
 import os
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ShellToolConfig(BaseModel):
@@ -10,6 +10,14 @@ class ShellToolConfig(BaseModel):
 
     enabled: bool = False
     allowed_commands: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_commands_if_enabled(self) -> "ShellToolConfig":
+        if self.enabled and not self.allowed_commands:
+            raise ValueError(
+                "shell.enabled=True requires at least one allowed_commands entry"
+            )
+        return self
 
 
 class FilesystemToolConfig(BaseModel):

--- a/src/configs/agent/openai_chat_agent.py
+++ b/src/configs/agent/openai_chat_agent.py
@@ -5,6 +5,40 @@ import os
 from pydantic import BaseModel, Field
 
 
+class ShellToolConfig(BaseModel):
+    """Configuration for the restricted shell tool."""
+
+    enabled: bool = False
+    allowed_commands: list[str] = Field(default_factory=list)
+
+
+class FilesystemToolConfig(BaseModel):
+    """Configuration for the filesystem tool."""
+
+    enabled: bool = False
+    root_dir: str = "/tmp/agent-workspace"
+
+
+class WebSearchToolConfig(BaseModel):
+    """Configuration for the web search tool."""
+
+    enabled: bool = False
+
+
+class BuiltinToolConfig(BaseModel):
+    """Configuration for all builtin tools."""
+
+    filesystem: FilesystemToolConfig = Field(default_factory=FilesystemToolConfig)
+    shell: ShellToolConfig = Field(default_factory=ShellToolConfig)
+    web_search: WebSearchToolConfig = Field(default_factory=WebSearchToolConfig)
+
+
+class ToolConfig(BaseModel):
+    """Top-level tool registry configuration."""
+
+    builtin: BuiltinToolConfig = Field(default_factory=BuiltinToolConfig)
+
+
 class OpenAIChatAgentConfig(BaseModel):
     """Configuration for OpenAI Chat Agent."""
 
@@ -31,7 +65,7 @@ class OpenAIChatAgentConfig(BaseModel):
         default=False,
         description="Whether the agent supports image inputs in messages",
     )
-    tool_config: dict | None = Field(
+    tool_config: ToolConfig | None = Field(
         default=None,
         description="Tool registry configuration for builtin tools (filesystem, shell, web_search)",
     )

--- a/src/main.py
+++ b/src/main.py
@@ -210,6 +210,15 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 logger.exception("Error stopping sweep service")
 
         try:
+            from src.services import get_agent_service
+
+            agent_svc = get_agent_service()
+            if agent_svc is not None and hasattr(agent_svc, "cleanup_async"):
+                await agent_svc.cleanup_async()
+        except Exception:
+            logger.exception("Error cleaning up agent MCP client")
+
+        try:
             from src.services.channel_service import cleanup_channel_service
 
             await cleanup_channel_service()

--- a/src/services/agent_service/middleware/__init__.py
+++ b/src/services/agent_service/middleware/__init__.py
@@ -1,5 +1,8 @@
 from src.services.agent_service.middleware.delegate_middleware import (
     DelegateToolMiddleware,
 )
+from src.services.agent_service.middleware.tool_gate_middleware import (
+    ToolGateMiddleware,
+)
 
-__all__ = ["DelegateToolMiddleware"]
+__all__ = ["DelegateToolMiddleware", "ToolGateMiddleware"]

--- a/src/services/agent_service/middleware/tool_gate_middleware.py
+++ b/src/services/agent_service/middleware/tool_gate_middleware.py
@@ -1,0 +1,106 @@
+"""ToolGateMiddleware — defense-in-depth validation of tool calls before execution."""
+
+from pathlib import Path
+
+from langchain.agents.middleware.types import AgentMiddleware
+from loguru import logger
+
+# Tool names for shell and filesystem tools
+_SHELL_TOOL_NAME = "terminal"
+_FILESYSTEM_TOOL_NAMES = frozenset(["read_file", "write_file", "list_directory"])
+
+
+class ToolGateMiddleware(AgentMiddleware):
+    """Validates tool calls against whitelist/path restrictions before execution.
+
+    This is a defense-in-depth layer. Even if tool-level restrictions are bypassed,
+    this middleware blocks dangerous calls at the middleware level.
+
+    Shell calls: the leading command token must be in ``allowed_commands``.
+    Filesystem calls: the target path must resolve within one of ``allowed_dirs``.
+    All other tools pass through unaffected.
+
+    When no restrictions are configured (empty lists), the middleware is permissive
+    and allows all calls.
+    """
+
+    def __init__(
+        self,
+        allowed_commands: list[str] | None = None,
+        allowed_dirs: list[str] | None = None,
+    ) -> None:
+        self._allowed_commands: list[str] = allowed_commands or []
+        self._allowed_dirs: list[str] = allowed_dirs or []
+
+    async def awrap_tool_call(self, request, handler):  # type: ignore[override]
+        tool_name: str = request.tool_call["name"]
+        args: dict = request.tool_call.get("args", {})
+
+        if tool_name == _SHELL_TOOL_NAME:
+            block_msg = self._check_shell(args)
+            if block_msg is not None:
+                return block_msg
+
+        if tool_name in _FILESYSTEM_TOOL_NAMES:
+            block_msg = self._check_filesystem(tool_name, args)
+            if block_msg is not None:
+                return block_msg
+
+        return await handler(request)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _check_shell(self, args: dict) -> str | None:
+        """Return an error string if the shell command is blocked, else None."""
+        if not self._allowed_commands:
+            # No restriction configured — permissive
+            return None
+
+        command_str: str = args.get("commands", "")
+        first_token = command_str.strip().split()[0] if command_str.strip() else ""
+
+        if first_token not in self._allowed_commands:
+            logger.warning(
+                f"ToolGate blocked shell command: first_token={first_token!r} "
+                f"allowed={self._allowed_commands}"
+            )
+            return (
+                f"Command '{first_token}' is not allowed. "
+                f"Allowed commands: {self._allowed_commands}"
+            )
+        return None
+
+    def _check_filesystem(self, tool_name: str, args: dict) -> str | None:
+        """Return an error string if the filesystem path is blocked, else None."""
+        if not self._allowed_dirs:
+            # No restriction configured — permissive
+            return None
+
+        # read_file / write_file use "file_path"; list_directory uses "dir_path"
+        raw_path: str = args.get("file_path") or args.get("dir_path") or ""
+        if not raw_path:
+            # No path argument — let the tool handle it
+            return None
+
+        try:
+            resolved = Path(raw_path).resolve()
+        except Exception:
+            logger.warning(
+                f"ToolGate blocked filesystem call: unresolvable path {raw_path!r}"
+            )
+            return f"Path '{raw_path}' could not be resolved."
+
+        for allowed in self._allowed_dirs:
+            try:
+                resolved.relative_to(Path(allowed).resolve())
+                return None  # within an allowed dir
+            except ValueError:
+                continue
+
+        logger.warning(
+            f"ToolGate blocked filesystem call: tool={tool_name!r} "
+            f"path={str(resolved)!r} allowed_dirs={self._allowed_dirs}"
+        )
+        return f"Path '{raw_path}' is outside the allowed directories: {self._allowed_dirs}"

--- a/src/services/agent_service/middleware/tool_gate_middleware.py
+++ b/src/services/agent_service/middleware/tool_gate_middleware.py
@@ -12,7 +12,7 @@ _SHELL_TOOL_NAME = "terminal"
 _FILESYSTEM_TOOL_NAMES = frozenset(["read_file", "write_file", "list_directory"])
 
 # Shell metacharacters that enable command chaining, pipes, subshells, etc.
-_DANGEROUS_SHELL_CHARS = re.compile(r"[;&|`$\n\\\"'(){}<>!]")
+_DANGEROUS_SHELL_CHARS = re.compile(r"[;&|`$\n(){}<>!]")
 
 
 class ToolGateMiddleware(AgentMiddleware):
@@ -38,7 +38,11 @@ class ToolGateMiddleware(AgentMiddleware):
     ) -> None:
         # Preserve None vs [] distinction — None means inactive, [] means deny all
         self._allowed_commands: list[str] | None = allowed_commands
-        self._allowed_dirs: list[str] | None = allowed_dirs
+        self._allowed_dirs: list[Path] | None = (
+            [Path(d).resolve() for d in allowed_dirs]
+            if allowed_dirs is not None
+            else None
+        )
 
     async def awrap_tool_call(self, request, handler):  # type: ignore[override]
         tool_name: str = request.tool_call["name"]
@@ -115,7 +119,7 @@ class ToolGateMiddleware(AgentMiddleware):
 
         for allowed in self._allowed_dirs:
             try:
-                resolved.relative_to(Path(allowed).resolve())
+                resolved.relative_to(allowed)
                 return None  # within an allowed dir
             except ValueError:
                 continue

--- a/src/services/agent_service/middleware/tool_gate_middleware.py
+++ b/src/services/agent_service/middleware/tool_gate_middleware.py
@@ -1,5 +1,7 @@
 """ToolGateMiddleware — defense-in-depth validation of tool calls before execution."""
 
+import re
+import shlex
 from pathlib import Path
 
 from langchain.agents.middleware.types import AgentMiddleware
@@ -8,6 +10,9 @@ from loguru import logger
 # Tool names for shell and filesystem tools
 _SHELL_TOOL_NAME = "terminal"
 _FILESYSTEM_TOOL_NAMES = frozenset(["read_file", "write_file", "list_directory"])
+
+# Shell metacharacters that enable command chaining, pipes, subshells, etc.
+_DANGEROUS_SHELL_CHARS = re.compile(r"[;&|`$\n\\\"'(){}<>!]")
 
 
 class ToolGateMiddleware(AgentMiddleware):
@@ -20,8 +25,10 @@ class ToolGateMiddleware(AgentMiddleware):
     Filesystem calls: the target path must resolve within one of ``allowed_dirs``.
     All other tools pass through unaffected.
 
-    When no restrictions are configured (empty lists), the middleware is permissive
-    and allows all calls.
+    ``allowed_commands=None`` / ``allowed_dirs=None`` — middleware inactive for that
+    category (no gating applied).
+    ``allowed_commands=[]`` / ``allowed_dirs=[]`` — active but nothing is allowed;
+    every call in that category is denied (fail-closed).
     """
 
     def __init__(
@@ -29,8 +36,9 @@ class ToolGateMiddleware(AgentMiddleware):
         allowed_commands: list[str] | None = None,
         allowed_dirs: list[str] | None = None,
     ) -> None:
-        self._allowed_commands: list[str] = allowed_commands or []
-        self._allowed_dirs: list[str] = allowed_dirs or []
+        # Preserve None vs [] distinction — None means inactive, [] means deny all
+        self._allowed_commands: list[str] | None = allowed_commands
+        self._allowed_dirs: list[str] | None = allowed_dirs
 
     async def awrap_tool_call(self, request, handler):  # type: ignore[override]
         tool_name: str = request.tool_call["name"]
@@ -54,35 +62,48 @@ class ToolGateMiddleware(AgentMiddleware):
 
     def _check_shell(self, args: dict) -> str | None:
         """Return an error string if the shell command is blocked, else None."""
-        if not self._allowed_commands:
-            # No restriction configured — permissive
-            return None
+        if self._allowed_commands is None:
+            return None  # middleware inactive for shell
 
         command_str: str = args.get("commands", "")
-        first_token = command_str.strip().split()[0] if command_str.strip() else ""
+        if not command_str.strip():
+            logger.warning("ToolGate blocked empty shell command")
+            return "Empty command is not allowed."
+
+        # Reject shell metacharacters that enable chaining, pipes, subshells, etc.
+        if _DANGEROUS_SHELL_CHARS.search(command_str):
+            logger.warning(f"ToolGate blocked shell metacharacters in: {command_str!r}")
+            return "Command contains disallowed shell characters."
+
+        try:
+            tokens = shlex.split(command_str)
+        except ValueError:
+            logger.warning(f"ToolGate blocked unparseable command: {command_str!r}")
+            return "Command could not be parsed."
+
+        first_token = tokens[0] if tokens else ""
 
         if first_token not in self._allowed_commands:
             logger.warning(
-                f"ToolGate blocked shell command: first_token={first_token!r} "
+                f"ToolGate blocked command: {first_token!r}, "
                 f"allowed={self._allowed_commands}"
             )
-            return (
-                f"Command '{first_token}' is not allowed. "
-                f"Allowed commands: {self._allowed_commands}"
-            )
+            return f"Command '{first_token}' is not permitted by security policy."
+
         return None
 
     def _check_filesystem(self, tool_name: str, args: dict) -> str | None:
         """Return an error string if the filesystem path is blocked, else None."""
-        if not self._allowed_dirs:
-            # No restriction configured — permissive
-            return None
+        if self._allowed_dirs is None:
+            return None  # middleware inactive for filesystem
 
         # read_file / write_file use "file_path"; list_directory uses "dir_path"
         raw_path: str = args.get("file_path") or args.get("dir_path") or ""
         if not raw_path:
-            # No path argument — let the tool handle it
-            return None
+            logger.warning(
+                f"ToolGate blocked filesystem tool called without path: {tool_name!r}"
+            )
+            return "Filesystem tool called without a recognized path argument."
 
         try:
             resolved = Path(raw_path).resolve()
@@ -90,7 +111,7 @@ class ToolGateMiddleware(AgentMiddleware):
             logger.warning(
                 f"ToolGate blocked filesystem call: unresolvable path {raw_path!r}"
             )
-            return f"Path '{raw_path}' could not be resolved."
+            return "Path could not be resolved."
 
         for allowed in self._allowed_dirs:
             try:
@@ -103,4 +124,4 @@ class ToolGateMiddleware(AgentMiddleware):
             f"ToolGate blocked filesystem call: tool={tool_name!r} "
             f"path={str(resolved)!r} allowed_dirs={self._allowed_dirs}"
         )
-        return f"Path '{raw_path}' is outside the allowed directories: {self._allowed_dirs}"
+        return "Path is outside the allowed directories."

--- a/src/services/agent_service/middleware/tool_gate_middleware.py
+++ b/src/services/agent_service/middleware/tool_gate_middleware.py
@@ -44,7 +44,7 @@ class ToolGateMiddleware(AgentMiddleware):
             else None
         )
 
-    async def awrap_tool_call(self, request, handler):  # type: ignore[override]
+    async def awrap_tool_call(self, request, handler):
         tool_name: str = request.tool_call["name"]
         args: dict = request.tool_call.get("args", {})
 
@@ -89,8 +89,7 @@ class ToolGateMiddleware(AgentMiddleware):
 
         if first_token not in self._allowed_commands:
             logger.warning(
-                f"ToolGate blocked command: {first_token!r}, "
-                f"allowed={self._allowed_commands}"
+                f"ToolGate blocked command: {first_token!r} (not in allowlist)"
             )
             return f"Command '{first_token}' is not permitted by security policy."
 
@@ -126,6 +125,6 @@ class ToolGateMiddleware(AgentMiddleware):
 
         logger.warning(
             f"ToolGate blocked filesystem call: tool={tool_name!r} "
-            f"path={str(resolved)!r} allowed_dirs={self._allowed_dirs}"
+            f"path={str(resolved)!r} (outside allowed directories)"
         )
         return "Path is outside the allowed directories."

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -1,4 +1,3 @@
-import traceback
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
@@ -42,8 +41,8 @@ def _load_personas() -> dict[str, str]:
             for pid, p in data.get("personas", {}).items()
             if "system_prompt" in p
         }
-    except Exception as e:
-        logger.error(f"Failed to load personas.yml: {e}")
+    except Exception:
+        logger.exception("Failed to load personas.yml")
         return {}
 
 
@@ -67,7 +66,6 @@ class OpenAIChatAgent(AgentService):
         self.model_name = model_name
         self.tool_config = tool_config
         self.agent = None
-        self._mcp_client: MultiServerMCPClient | None = None
         self._mcp_tools: list = []
         self._personas: dict[str, str] = {}
         super().__init__(**kwargs)
@@ -89,18 +87,14 @@ class OpenAIChatAgent(AgentService):
         self._personas = _load_personas()
         logger.info(f"Loaded {len(self._personas)} personas: {list(self._personas)}")
 
-        # 2. Start persistent MCP client (keeps stdio subprocesses alive)
+        # 2. Load MCP tools via stateless client (langchain-mcp-adapters 0.2.2+)
         if self.mcp_config:
             try:
-                self._mcp_client = MultiServerMCPClient(self.mcp_config)
-                await self._mcp_client.__aenter__()
-                self._mcp_tools = self._mcp_client.get_tools()
-                logger.info(f"MCP client started with {len(self._mcp_tools)} tools")
-            except Exception as e:
-                logger.error(
-                    f"Failed to start MCP client, continuing without MCP tools: {e}"
-                )
-                self._mcp_client = None
+                client = MultiServerMCPClient(self.mcp_config)
+                self._mcp_tools = await client.get_tools()
+                logger.info(f"Loaded {len(self._mcp_tools)} MCP tools")
+            except Exception:
+                logger.exception("Failed to load MCP tools, continuing without")
                 self._mcp_tools = []
 
         # 3. Create single agent instance
@@ -166,15 +160,8 @@ class OpenAIChatAgent(AgentService):
         logger.info("Agent created successfully")
 
     async def cleanup_async(self) -> None:
-        """Shut down the persistent MCP client if one is running."""
-        if self._mcp_client is not None:
-            try:
-                await self._mcp_client.__aexit__(None, None, None)
-                logger.info("MCP client closed")
-            except Exception as e:
-                logger.error(f"Error closing MCP client: {e}")
-            finally:
-                self._mcp_client = None
+        """No-op: stateless MCP client requires no shutdown."""
+        logger.info("MCP cleanup: nothing to clean up (stateless client)")
 
     async def is_healthy(self) -> tuple[bool, str]:
         """Check if the agent is healthy and ready."""
@@ -185,7 +172,7 @@ class OpenAIChatAgent(AgentService):
                 continue
             return True, "Agent is healthy."
         except Exception as e:
-            logger.error(f"Health check failed: {e}")
+            logger.exception("Health check failed")
             return False, f"Health check failed: {e}"
 
     async def stream(
@@ -250,9 +237,8 @@ class OpenAIChatAgent(AgentService):
                     "content": content,
                     "new_chats": new_chats,
                 }
-        except Exception as e:
-            logger.error(f"Error in stream method: {e}")
-            traceback.print_exc()
+        except Exception:
+            logger.exception("Error in stream method")
             raise
 
     async def invoke(
@@ -295,9 +281,8 @@ class OpenAIChatAgent(AgentService):
             logger.info(f"Invoke completed: {len(new_chats)} new messages")
             return {"content": content, "new_chats": new_chats}
 
-        except Exception as e:
-            logger.error(f"Error in invoke method: {e}")
-            traceback.print_exc()
+        except Exception:
+            logger.exception("Error in invoke method")
             raise
 
     @staticmethod
@@ -379,8 +364,8 @@ class OpenAIChatAgent(AgentService):
             yield {"type": "final_response", "data": new_chats}
             logger.info(f"Processing completed: {chunk_count} chunks")
 
-        except Exception as e:
-            logger.error(f"Error in process_message: {e}")
+        except Exception:
+            logger.exception("Error in process_message")
             if remaining := buffer.flush():
                 yield self._flush_buffer(node, remaining)
             yield {"type": "error", "error": "메시지 처리 중 오류가 발생했습니다."}

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -159,8 +159,8 @@ class OpenAIChatAgent(AgentService):
             state_schema=CustomAgentState,
             checkpointer=checkpointer,
             middleware=[
-                DelegateToolMiddleware(),
                 tool_gate,
+                DelegateToolMiddleware(),
                 before_model(profile_retrieve_hook),
                 before_model(summary_inject_hook),
                 before_model(ltm_retrieve_hook),

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -67,6 +67,7 @@ class OpenAIChatAgent(AgentService):
         self.model_name = model_name
         self.tool_config = tool_config
         self.agent = None
+        self._mcp_client: MultiServerMCPClient | None = None
         self._mcp_tools: list = []
         self._personas: dict[str, str] = {}
         super().__init__(**kwargs)
@@ -88,11 +89,19 @@ class OpenAIChatAgent(AgentService):
         self._personas = _load_personas()
         logger.info(f"Loaded {len(self._personas)} personas: {list(self._personas)}")
 
-        # 2. Fetch MCP tools once
+        # 2. Start persistent MCP client (keeps stdio subprocesses alive)
         if self.mcp_config:
-            async with MultiServerMCPClient(self.mcp_config) as client:
-                self._mcp_tools = await client.get_tools()
-            logger.info(f"Cached {len(self._mcp_tools)} MCP tools")
+            try:
+                self._mcp_client = MultiServerMCPClient(self.mcp_config)
+                await self._mcp_client.__aenter__()
+                self._mcp_tools = self._mcp_client.get_tools()
+                logger.info(f"MCP client started with {len(self._mcp_tools)} tools")
+            except Exception as e:
+                logger.error(
+                    f"Failed to start MCP client, continuing without MCP tools: {e}"
+                )
+                self._mcp_client = None
+                self._mcp_tools = []
 
         # 3. Create single agent instance
         from langchain.agents.middleware import after_model, before_model
@@ -155,6 +164,17 @@ class OpenAIChatAgent(AgentService):
             ],
         )
         logger.info("Agent created successfully")
+
+    async def cleanup_async(self) -> None:
+        """Shut down the persistent MCP client if one is running."""
+        if self._mcp_client is not None:
+            try:
+                await self._mcp_client.__aexit__(None, None, None)
+                logger.info("MCP client closed")
+            except Exception as e:
+                logger.error(f"Error closing MCP client: {e}")
+            finally:
+                self._mcp_client = None
 
     async def is_healthy(self) -> tuple[bool, str]:
         """Check if the agent is healthy and ready."""

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -20,6 +20,9 @@ from loguru import logger
 from src.services.agent_service.middleware.delegate_middleware import (
     DelegateToolMiddleware,
 )
+from src.services.agent_service.middleware.tool_gate_middleware import (
+    ToolGateMiddleware,
+)
 from src.services.agent_service.service import AgentService
 from src.services.agent_service.state import CustomAgentState
 from src.services.agent_service.utils.streaming_buffer import StreamingBuffer
@@ -140,6 +143,16 @@ class OpenAIChatAgent(AgentService):
             )
             custom_tools.extend(builtin_tools)
 
+        builtin_cfg: dict = (self.tool_config or {}).get("builtin", {})
+        tool_gate = ToolGateMiddleware(
+            allowed_commands=builtin_cfg.get("shell", {}).get("allowed_commands"),
+            allowed_dirs=(
+                [builtin_cfg.get("filesystem", {}).get("root_dir")]
+                if builtin_cfg.get("filesystem", {}).get("root_dir")
+                else None
+            ),
+        )
+
         self.agent = create_agent(
             model=self.llm,
             tools=custom_tools,
@@ -147,6 +160,7 @@ class OpenAIChatAgent(AgentService):
             checkpointer=checkpointer,
             middleware=[
                 DelegateToolMiddleware(),
+                tool_gate,
                 before_model(profile_retrieve_hook),
                 before_model(summary_inject_hook),
                 before_model(ltm_retrieve_hook),

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -57,6 +57,7 @@ class OpenAIChatAgent(AgentService):
         openai_api_key: str | None = None,
         openai_api_base: str | None = None,
         model_name: str | None = None,
+        tool_config: dict | None = None,
         **kwargs,
     ):
         self.temperature = temperature
@@ -64,6 +65,7 @@ class OpenAIChatAgent(AgentService):
         self.openai_api_key = openai_api_key
         self.openai_api_base = openai_api_base
         self.model_name = model_name
+        self.tool_config = tool_config
         self.agent = None
         self._mcp_tools: list = []
         self._personas: dict[str, str] = {}
@@ -128,6 +130,15 @@ class OpenAIChatAgent(AgentService):
         profile_svc = get_user_profile_service()
         if profile_svc is not None:
             custom_tools.append(UpdateUserProfileTool(service=profile_svc))
+
+        from src.services.agent_service.tools.registry import ToolRegistry
+
+        builtin_tools = ToolRegistry(self.tool_config).get_enabled_tools()
+        if builtin_tools:
+            logger.info(
+                f"Adding {len(builtin_tools)} builtin tools: {[t.name for t in builtin_tools]}"
+            )
+            custom_tools.extend(builtin_tools)
 
         self.agent = create_agent(
             model=self.llm,

--- a/src/services/agent_service/tools/builtin/__init__.py
+++ b/src/services/agent_service/tools/builtin/__init__.py
@@ -1,0 +1,9 @@
+"""Builtin LangChain tool wrappers for the agent."""
+
+from src.services.agent_service.tools.builtin.filesystem_tools import (
+    get_filesystem_tools,
+)
+from src.services.agent_service.tools.builtin.search_tools import get_search_tools
+from src.services.agent_service.tools.builtin.shell_tools import get_shell_tools
+
+__all__ = ["get_filesystem_tools", "get_search_tools", "get_shell_tools"]

--- a/src/services/agent_service/tools/builtin/filesystem_tools.py
+++ b/src/services/agent_service/tools/builtin/filesystem_tools.py
@@ -1,0 +1,26 @@
+"""Filesystem tools backed by LangChain community file management tools."""
+
+from langchain_community.tools.file_management import (
+    ListDirectoryTool,
+    ReadFileTool,
+    WriteFileTool,
+)
+from langchain_core.tools import BaseTool
+from loguru import logger
+
+
+def get_filesystem_tools(root_dir: str) -> list[BaseTool]:
+    """Return ReadFileTool, WriteFileTool, and ListDirectoryTool scoped to root_dir.
+
+    Args:
+        root_dir: Filesystem path that all file operations are restricted to.
+
+    Returns:
+        List of three BaseTool instances for file read, write, and list.
+    """
+    logger.info(f"Filesystem tools enabled (root_dir={root_dir})")
+    return [
+        ReadFileTool(root_dir=root_dir),
+        WriteFileTool(root_dir=root_dir),
+        ListDirectoryTool(root_dir=root_dir),
+    ]

--- a/src/services/agent_service/tools/builtin/search_tools.py
+++ b/src/services/agent_service/tools/builtin/search_tools.py
@@ -1,0 +1,15 @@
+"""Web search tool backed by DuckDuckGo."""
+
+from langchain_community.tools import DuckDuckGoSearchRun
+from langchain_core.tools import BaseTool
+from loguru import logger
+
+
+def get_search_tools() -> list[BaseTool]:
+    """Return a DuckDuckGoSearchRun tool.
+
+    Returns:
+        List containing one DuckDuckGoSearchRun instance.
+    """
+    logger.info("Web search tool (DuckDuckGo) enabled")
+    return [DuckDuckGoSearchRun()]

--- a/src/services/agent_service/tools/builtin/shell_tools.py
+++ b/src/services/agent_service/tools/builtin/shell_tools.py
@@ -1,0 +1,69 @@
+"""Shell tool wrapper with command whitelist enforcement."""
+
+import subprocess
+
+from langchain_core.tools import BaseTool
+from loguru import logger
+
+
+class RestrictedShellTool(BaseTool):
+    """BaseTool that validates commands against a whitelist before execution.
+
+    Only commands whose first token appears in ``allowed_commands`` are executed
+    via subprocess. All other commands are rejected with an error message.
+    """
+
+    name: str = "terminal"
+    description: str = (
+        "Run shell commands. Only whitelisted commands are permitted. "
+        "Input should be a valid shell command string."
+    )
+    allowed_commands: list[str]
+
+    def _run(self, commands: str) -> str:  # type: ignore[override]
+        """Execute ``commands`` if the leading token is whitelisted.
+
+        Args:
+            commands: Shell command string to execute.
+
+        Returns:
+            Command stdout/stderr output, or an error message if blocked.
+        """
+        first_token = commands.strip().split()[0] if commands.strip() else ""
+        if first_token not in self.allowed_commands:
+            logger.warning(f"Shell command blocked (not allowed): {first_token!r}")
+            return (
+                f"Command '{first_token}' is not allowed. "
+                f"Allowed commands: {self.allowed_commands}"
+            )
+        logger.info(f"Shell command executing: {commands!r}")
+        try:
+            result = subprocess.run(
+                commands,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            output = result.stdout
+            if result.stderr:
+                output += result.stderr
+            return output
+        except subprocess.TimeoutExpired:
+            return "Command timed out after 30 seconds."
+        except Exception as e:
+            logger.error(f"Shell command failed: {e}")
+            return f"Command failed: {e}"
+
+
+def get_shell_tools(allowed_commands: list[str]) -> list[BaseTool]:
+    """Return a single RestrictedShellTool enforcing the given whitelist.
+
+    Args:
+        allowed_commands: List of command names (first tokens) that are permitted.
+
+    Returns:
+        List containing one RestrictedShellTool.
+    """
+    logger.info(f"Shell tool enabled (allowed_commands={allowed_commands})")
+    return [RestrictedShellTool(allowed_commands=allowed_commands)]

--- a/src/services/agent_service/tools/builtin/shell_tools.py
+++ b/src/services/agent_service/tools/builtin/shell_tools.py
@@ -3,7 +3,6 @@
 import re
 import shlex
 import subprocess
-from typing import Any
 
 from langchain_core.tools import BaseTool
 from loguru import logger
@@ -26,7 +25,7 @@ class RestrictedShellTool(BaseTool):
     )
     allowed_commands: list[str]
 
-    def _run(self, query: str, **kwargs: Any) -> str:
+    def _run(self, query: str, **kwargs: object) -> str:
         """Execute ``query`` if the leading token is whitelisted.
 
         Args:

--- a/src/services/agent_service/tools/builtin/shell_tools.py
+++ b/src/services/agent_service/tools/builtin/shell_tools.py
@@ -1,9 +1,14 @@
 """Shell tool wrapper with command whitelist enforcement."""
 
+import re
+import shlex
 import subprocess
+from typing import Any
 
 from langchain_core.tools import BaseTool
 from loguru import logger
+
+_DANGEROUS_SHELL_CHARS = re.compile(r"[;&|`$\n\\\"'(){}<>!]")
 
 
 class RestrictedShellTool(BaseTool):
@@ -11,6 +16,7 @@ class RestrictedShellTool(BaseTool):
 
     Only commands whose first token appears in ``allowed_commands`` are executed
     via subprocess. All other commands are rejected with an error message.
+    Shell metacharacters are rejected to prevent injection attacks.
     """
 
     name: str = "terminal"
@@ -20,27 +26,41 @@ class RestrictedShellTool(BaseTool):
     )
     allowed_commands: list[str]
 
-    def _run(self, commands: str) -> str:  # type: ignore[override]
-        """Execute ``commands`` if the leading token is whitelisted.
+    def _run(self, query: str, **kwargs: Any) -> str:
+        """Execute ``query`` if the leading token is whitelisted.
 
         Args:
-            commands: Shell command string to execute.
+            query: Shell command string to execute.
 
         Returns:
             Command stdout/stderr output, or an error message if blocked.
         """
-        first_token = commands.strip().split()[0] if commands.strip() else ""
-        if first_token not in self.allowed_commands:
-            logger.warning(f"Shell command blocked (not allowed): {first_token!r}")
+        commands = query
+        if not commands.strip():
+            return "Empty command is not allowed."
+
+        if _DANGEROUS_SHELL_CHARS.search(commands):
+            logger.warning("Shell command blocked (dangerous characters detected)")
+            return "Command contains disallowed shell characters."
+
+        try:
+            tokens = shlex.split(commands)
+        except ValueError:
+            return "Command could not be parsed."
+
+        if not tokens or tokens[0] not in self.allowed_commands:
+            first = tokens[0] if tokens else ""
+            logger.warning(f"Shell command blocked (not allowed): {first!r}")
             return (
-                f"Command '{first_token}' is not allowed. "
+                f"Command '{first}' is not permitted by security policy. "
                 f"Allowed commands: {self.allowed_commands}"
             )
+
         logger.info(f"Shell command executing: {commands!r}")
         try:
             result = subprocess.run(
-                commands,
-                shell=True,
+                tokens,
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=30,
@@ -52,7 +72,7 @@ class RestrictedShellTool(BaseTool):
         except subprocess.TimeoutExpired:
             return "Command timed out after 30 seconds."
         except Exception as e:
-            logger.error(f"Shell command failed: {e}")
+            logger.exception(f"Shell command failed: {e}")
             return f"Command failed: {e}"
 
 

--- a/src/services/agent_service/tools/builtin/shell_tools.py
+++ b/src/services/agent_service/tools/builtin/shell_tools.py
@@ -8,7 +8,7 @@ from typing import Any
 from langchain_core.tools import BaseTool
 from loguru import logger
 
-_DANGEROUS_SHELL_CHARS = re.compile(r"[;&|`$\n\\\"'(){}<>!]")
+_DANGEROUS_SHELL_CHARS = re.compile(r"[;&|`$\n(){}<>!]")
 
 
 class RestrictedShellTool(BaseTool):
@@ -67,6 +67,8 @@ class RestrictedShellTool(BaseTool):
             )
             output = result.stdout
             if result.stderr:
+                if output and not output.endswith("\n"):
+                    output += "\n"
                 output += result.stderr
             return output
         except subprocess.TimeoutExpired:

--- a/src/services/agent_service/tools/registry.py
+++ b/src/services/agent_service/tools/registry.py
@@ -3,12 +3,15 @@
 from langchain_core.tools import BaseTool
 from loguru import logger
 
+from src.configs.agent.openai_chat_agent import BuiltinToolConfig, ToolConfig
+
 
 class ToolRegistry:
-    """Instantiates and returns enabled tools based on a ``tool_config`` dict.
+    """Instantiates and returns enabled tools based on a ``ToolConfig``.
 
     The registry reads the ``builtin`` section of the config and instantiates
-    only the tools whose ``enabled`` flag is ``True``.
+    only the tools whose ``enabled`` flag is ``True``. Accepts either a
+    ``ToolConfig`` instance or a raw dict (which is validated via Pydantic).
 
     Example config structure::
 
@@ -24,8 +27,13 @@ class ToolRegistry:
               enabled: false
     """
 
-    def __init__(self, tool_config: dict | None) -> None:
-        self._tool_config = tool_config or {}
+    def __init__(self, tool_config: ToolConfig | dict | None) -> None:
+        if tool_config is None:
+            self._config: ToolConfig | None = None
+        elif isinstance(tool_config, dict):
+            self._config = ToolConfig.model_validate(tool_config)
+        else:
+            self._config = tool_config
 
     def get_enabled_tools(self) -> list[BaseTool]:
         """Return all enabled builtin tools as a flat list.
@@ -33,34 +41,31 @@ class ToolRegistry:
         Returns:
             List of BaseTool instances for each enabled category.
         """
-        builtin: dict = self._tool_config.get("builtin", {})
-        if not builtin:
+        if self._config is None:
             return []
 
+        builtin: BuiltinToolConfig = self._config.builtin
         tools: list[BaseTool] = []
 
-        fs_cfg: dict = builtin.get("filesystem", {})
-        if fs_cfg.get("enabled"):
+        if builtin.filesystem.enabled:
             from src.services.agent_service.tools.builtin.filesystem_tools import (
                 get_filesystem_tools,
             )
 
-            root_dir: str = fs_cfg.get("root_dir", "/tmp/agent-workspace")
-            tools.extend(get_filesystem_tools(root_dir=root_dir))
+            tools.extend(get_filesystem_tools(root_dir=builtin.filesystem.root_dir))
             logger.info("ToolRegistry: filesystem tools added")
 
-        shell_cfg: dict = builtin.get("shell", {})
-        if shell_cfg.get("enabled"):
+        if builtin.shell.enabled:
             from src.services.agent_service.tools.builtin.shell_tools import (
                 get_shell_tools,
             )
 
-            allowed: list[str] = shell_cfg.get("allowed_commands", [])
-            tools.extend(get_shell_tools(allowed_commands=allowed))
+            tools.extend(
+                get_shell_tools(allowed_commands=builtin.shell.allowed_commands)
+            )
             logger.info("ToolRegistry: shell tool added")
 
-        search_cfg: dict = builtin.get("web_search", {})
-        if search_cfg.get("enabled"):
+        if builtin.web_search.enabled:
             from src.services.agent_service.tools.builtin.search_tools import (
                 get_search_tools,
             )

--- a/src/services/agent_service/tools/registry.py
+++ b/src/services/agent_service/tools/registry.py
@@ -1,0 +1,71 @@
+"""Tool registry that instantiates enabled builtin tools from YAML config."""
+
+from langchain_core.tools import BaseTool
+from loguru import logger
+
+
+class ToolRegistry:
+    """Instantiates and returns enabled tools based on a ``tool_config`` dict.
+
+    The registry reads the ``builtin`` section of the config and instantiates
+    only the tools whose ``enabled`` flag is ``True``.
+
+    Example config structure::
+
+        tool_config:
+          builtin:
+            filesystem:
+              enabled: false
+              root_dir: "/tmp/agent-workspace"
+            shell:
+              enabled: false
+              allowed_commands: ["ls", "cat"]
+            web_search:
+              enabled: false
+    """
+
+    def __init__(self, tool_config: dict | None) -> None:
+        self._tool_config = tool_config or {}
+
+    def get_enabled_tools(self) -> list[BaseTool]:
+        """Return all enabled builtin tools as a flat list.
+
+        Returns:
+            List of BaseTool instances for each enabled category.
+        """
+        builtin: dict = self._tool_config.get("builtin", {})
+        if not builtin:
+            return []
+
+        tools: list[BaseTool] = []
+
+        fs_cfg: dict = builtin.get("filesystem", {})
+        if fs_cfg.get("enabled"):
+            from src.services.agent_service.tools.builtin.filesystem_tools import (
+                get_filesystem_tools,
+            )
+
+            root_dir: str = fs_cfg.get("root_dir", "/tmp/agent-workspace")
+            tools.extend(get_filesystem_tools(root_dir=root_dir))
+            logger.info("ToolRegistry: filesystem tools added")
+
+        shell_cfg: dict = builtin.get("shell", {})
+        if shell_cfg.get("enabled"):
+            from src.services.agent_service.tools.builtin.shell_tools import (
+                get_shell_tools,
+            )
+
+            allowed: list[str] = shell_cfg.get("allowed_commands", [])
+            tools.extend(get_shell_tools(allowed_commands=allowed))
+            logger.info("ToolRegistry: shell tool added")
+
+        search_cfg: dict = builtin.get("web_search", {})
+        if search_cfg.get("enabled"):
+            from src.services.agent_service.tools.builtin.search_tools import (
+                get_search_tools,
+            )
+
+            tools.extend(get_search_tools())
+            logger.info("ToolRegistry: web search tool added")
+
+        return tools

--- a/src/services/service_manager.py
+++ b/src/services/service_manager.py
@@ -374,6 +374,7 @@ def initialize_agent_service(
 
     def _inject_mcp(config: dict, service_configs: dict) -> None:
         service_configs["mcp_config"] = config.get("mcp_config")
+        service_configs["tool_config"] = config.get("tool_config")
 
     _agent_service_instance = _initialize_service(
         service_name="Agent",

--- a/src/services/service_manager.py
+++ b/src/services/service_manager.py
@@ -372,7 +372,7 @@ def initialize_agent_service(
         logger.debug("Agent service already initialized, skipping")
         return _agent_service_instance
 
-    def _inject_mcp(config: dict, service_configs: dict) -> None:
+    def _inject_extra_config(config: dict, service_configs: dict) -> None:
         service_configs["mcp_config"] = config.get("mcp_config")
         service_configs["tool_config"] = config.get("tool_config")
 
@@ -385,7 +385,7 @@ def initialize_agent_service(
         config_key="llm_config",
         factory_fn=AgentFactory.get_agent_service,
         config_path=config_path,
-        pre_factory_hook=_inject_mcp,
+        pre_factory_hook=_inject_extra_config,
         async_health_check=True,
         swallow_health_error=True,
     )

--- a/tests/services/agent_service/middleware/test_tool_gate_middleware.py
+++ b/tests/services/agent_service/middleware/test_tool_gate_middleware.py
@@ -38,19 +38,21 @@ class TestShellGating:
 
         handler.assert_not_called()
         assert "rm" in result
-        assert "not allowed" in result
+        assert "not permitted" in result
 
-    async def test_empty_allowed_commands_is_permissive(self):
+    async def test_empty_allowed_commands_denies_all(self):
+        """allowed_commands=[] is active but nothing allowed — fail-closed."""
         gate = ToolGateMiddleware(allowed_commands=[])
         request = _make_request("terminal", {"commands": "rm -rf /"})
         handler = AsyncMock(return_value="executed")
 
         result = await gate.awrap_tool_call(request, handler)
 
-        handler.assert_called_once_with(request)
-        assert result == "executed"
+        handler.assert_not_called()
+        assert "not permitted" in result
 
-    async def test_none_allowed_commands_is_permissive(self):
+    async def test_none_allowed_commands_is_inactive(self):
+        """allowed_commands=None means middleware is inactive — no gating."""
         gate = ToolGateMiddleware(allowed_commands=None)
         request = _make_request("terminal", {"commands": "anything goes"})
         handler = AsyncMock(return_value="executed")
@@ -60,7 +62,8 @@ class TestShellGating:
         handler.assert_called_once_with(request)
         assert result == "executed"
 
-    async def test_blocked_command_message_includes_allowed_list(self):
+    async def test_blocked_command_message_does_not_leak_whitelist(self):
+        """Error messages must not reveal the allowed command list."""
         gate = ToolGateMiddleware(allowed_commands=["ls"])
         request = _make_request("terminal", {"commands": "curl http://evil.com"})
         handler = AsyncMock()
@@ -68,7 +71,9 @@ class TestShellGating:
         result = await gate.awrap_tool_call(request, handler)
 
         assert "curl" in result
-        assert "ls" in result
+        # The whitelist itself must NOT appear in the error message
+        assert "['ls']" not in result
+        assert "allowed_commands" not in result
 
     async def test_empty_command_string_blocked_when_restrictions_set(self):
         gate = ToolGateMiddleware(allowed_commands=["ls"])
@@ -78,7 +83,81 @@ class TestShellGating:
         result = await gate.awrap_tool_call(request, handler)
 
         handler.assert_not_called()
-        assert "not allowed" in result
+        assert result  # some error message returned
+
+
+class TestShellBypassPrevention:
+    """Tests that shell metacharacter injection attacks are blocked."""
+
+    async def test_semicolon_chaining_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "ls; rm -rf /"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "disallowed shell characters" in result
+
+    async def test_double_ampersand_chaining_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "ls && cat /etc/passwd"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "disallowed shell characters" in result
+
+    async def test_pipe_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "ls | xargs rm"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "disallowed shell characters" in result
+
+    async def test_subshell_dollar_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "ls $(whoami)"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "disallowed shell characters" in result
+
+    async def test_backtick_subshell_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "ls `id`"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "disallowed shell characters" in result
+
+    async def test_newline_injection_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "ls\nrm -rf /"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "disallowed shell characters" in result
+
+    async def test_empty_command_blocked(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "   "})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert result  # some error message returned
 
 
 class TestFilesystemGating:
@@ -146,17 +225,19 @@ class TestFilesystemGating:
         handler.assert_not_called()
         assert "outside the allowed" in result
 
-    async def test_empty_allowed_dirs_is_permissive(self):
+    async def test_empty_allowed_dirs_denies_all(self):
+        """allowed_dirs=[] is active but nothing allowed — fail-closed."""
         gate = ToolGateMiddleware(allowed_dirs=[])
         request = _make_request("read_file", {"file_path": "/etc/passwd"})
-        handler = AsyncMock(return_value="executed")
+        handler = AsyncMock()
 
         result = await gate.awrap_tool_call(request, handler)
 
-        handler.assert_called_once_with(request)
-        assert result == "executed"
+        handler.assert_not_called()
+        assert result  # some error message returned
 
-    async def test_none_allowed_dirs_is_permissive(self):
+    async def test_none_allowed_dirs_is_inactive(self):
+        """allowed_dirs=None means middleware is inactive — no gating."""
         gate = ToolGateMiddleware(allowed_dirs=None)
         request = _make_request("write_file", {"file_path": "/etc/shadow"})
         handler = AsyncMock(return_value="executed")
@@ -180,15 +261,27 @@ class TestFilesystemGating:
         handler.assert_not_called()
         assert "outside the allowed" in result
 
-    async def test_no_path_arg_passes_through(self):
+    async def test_missing_path_arg_is_blocked(self):
+        """Filesystem tool called without a path argument must be blocked."""
         gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
         request = _make_request("read_file", {})
-        handler = AsyncMock(return_value="executed")
+        handler = AsyncMock()
 
         result = await gate.awrap_tool_call(request, handler)
 
-        handler.assert_called_once_with(request)
-        assert result == "executed"
+        handler.assert_not_called()
+        assert result  # some error message returned
+
+    async def test_error_message_does_not_leak_allowed_dirs(self):
+        """Error messages must not reveal the allowed_dirs list."""
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request("read_file", {"file_path": "/etc/passwd"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        assert "/tmp/agent-workspace" not in result
+        assert "allowed_dirs" not in result
 
 
 class TestNonGatedTools:
@@ -234,6 +327,7 @@ class TestNonGatedTools:
 
 class TestPermissiveDefaults:
     async def test_no_config_allows_all_shell(self):
+        """Default (None, None) — middleware fully inactive."""
         gate = ToolGateMiddleware()
         request = _make_request("terminal", {"commands": "rm -rf /"})
         handler = AsyncMock(return_value="executed")
@@ -243,6 +337,7 @@ class TestPermissiveDefaults:
         handler.assert_called_once_with(request)
 
     async def test_no_config_allows_all_filesystem(self):
+        """Default (None, None) — middleware fully inactive."""
         gate = ToolGateMiddleware()
         request = _make_request("read_file", {"file_path": "/etc/shadow"})
         handler = AsyncMock(return_value="executed")

--- a/tests/services/agent_service/middleware/test_tool_gate_middleware.py
+++ b/tests/services/agent_service/middleware/test_tool_gate_middleware.py
@@ -1,0 +1,252 @@
+"""Tests for ToolGateMiddleware — defense-in-depth tool call validation."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from src.services.agent_service.middleware.tool_gate_middleware import (
+    ToolGateMiddleware,
+)
+
+
+def _make_request(tool_name: str, args: dict) -> MagicMock:
+    """Build a fake ToolCallRequest-like object."""
+    request = MagicMock()
+    request.tool_call = {"name": tool_name, "args": args}
+    return request
+
+
+async def _pass_through_handler(request):
+    return "executed"
+
+
+class TestShellGating:
+    async def test_allowed_command_passes_through(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls", "cat"])
+        request = _make_request("terminal", {"commands": "ls -la /tmp"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_blocked_command_returns_error(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls", "cat"])
+        request = _make_request("terminal", {"commands": "rm -rf /"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "rm" in result
+        assert "not allowed" in result
+
+    async def test_empty_allowed_commands_is_permissive(self):
+        gate = ToolGateMiddleware(allowed_commands=[])
+        request = _make_request("terminal", {"commands": "rm -rf /"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_none_allowed_commands_is_permissive(self):
+        gate = ToolGateMiddleware(allowed_commands=None)
+        request = _make_request("terminal", {"commands": "anything goes"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_blocked_command_message_includes_allowed_list(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": "curl http://evil.com"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        assert "curl" in result
+        assert "ls" in result
+
+    async def test_empty_command_string_blocked_when_restrictions_set(self):
+        gate = ToolGateMiddleware(allowed_commands=["ls"])
+        request = _make_request("terminal", {"commands": ""})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "not allowed" in result
+
+
+class TestFilesystemGating:
+    async def test_path_within_allowed_dir_passes(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request(
+            "read_file", {"file_path": "/tmp/agent-workspace/file.txt"}
+        )
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_path_outside_allowed_dir_is_blocked(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request("read_file", {"file_path": "/etc/passwd"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "outside the allowed" in result
+
+    async def test_write_file_within_allowed_dir_passes(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request(
+            "write_file", {"file_path": "/tmp/agent-workspace/out.txt"}
+        )
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_write_file_outside_allowed_dir_is_blocked(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request("write_file", {"file_path": "/home/user/.bashrc"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "outside the allowed" in result
+
+    async def test_list_directory_within_allowed_dir_passes(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request("list_directory", {"dir_path": "/tmp/agent-workspace"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_list_directory_outside_blocked(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request("list_directory", {"dir_path": "/var/log"})
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "outside the allowed" in result
+
+    async def test_empty_allowed_dirs_is_permissive(self):
+        gate = ToolGateMiddleware(allowed_dirs=[])
+        request = _make_request("read_file", {"file_path": "/etc/passwd"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_none_allowed_dirs_is_permissive(self):
+        gate = ToolGateMiddleware(allowed_dirs=None)
+        request = _make_request("write_file", {"file_path": "/etc/shadow"})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+    async def test_path_traversal_blocked(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        # Path traversal attempt that resolves outside allowed dir
+        request = _make_request(
+            "read_file",
+            {"file_path": "/tmp/agent-workspace/../../../etc/passwd"},
+        )
+        handler = AsyncMock()
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert "outside the allowed" in result
+
+    async def test_no_path_arg_passes_through(self):
+        gate = ToolGateMiddleware(allowed_dirs=["/tmp/agent-workspace"])
+        request = _make_request("read_file", {})
+        handler = AsyncMock(return_value="executed")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "executed"
+
+
+class TestNonGatedTools:
+    async def test_memory_tool_passes_through_unaffected(self):
+        gate = ToolGateMiddleware(
+            allowed_commands=["ls"],
+            allowed_dirs=["/tmp/agent-workspace"],
+        )
+        request = _make_request("save_memory", {"content": "remember this"})
+        handler = AsyncMock(return_value="memory_saved")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "memory_saved"
+
+    async def test_delegate_task_tool_passes_through(self):
+        gate = ToolGateMiddleware(
+            allowed_commands=["ls"],
+            allowed_dirs=["/tmp/agent-workspace"],
+        )
+        request = _make_request("delegate_task", {"task": "do something"})
+        handler = AsyncMock(return_value="delegated")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "delegated"
+
+    async def test_web_search_tool_passes_through(self):
+        gate = ToolGateMiddleware(
+            allowed_commands=["ls"],
+            allowed_dirs=["/tmp/agent-workspace"],
+        )
+        request = _make_request("web_search", {"query": "python docs"})
+        handler = AsyncMock(return_value="search_result")
+
+        result = await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert result == "search_result"
+
+
+class TestPermissiveDefaults:
+    async def test_no_config_allows_all_shell(self):
+        gate = ToolGateMiddleware()
+        request = _make_request("terminal", {"commands": "rm -rf /"})
+        handler = AsyncMock(return_value="executed")
+
+        await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+
+    async def test_no_config_allows_all_filesystem(self):
+        gate = ToolGateMiddleware()
+        request = _make_request("read_file", {"file_path": "/etc/shadow"})
+        handler = AsyncMock(return_value="executed")
+
+        await gate.awrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)

--- a/tests/services/agent_service/test_mcp_lifecycle.py
+++ b/tests/services/agent_service/test_mcp_lifecycle.py
@@ -1,0 +1,140 @@
+"""Tests for MCP client lifecycle in OpenAIChatAgent.
+
+Covers:
+- Agent initializes correctly with mcp_config=None (no MCP)
+- Agent gracefully degrades when MCP server fails to start
+- cleanup_async() is safe to call when no MCP client exists
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.services.agent_service.openai_chat_agent import OpenAIChatAgent
+
+
+def make_agent(mcp_config: dict | None = None) -> OpenAIChatAgent:
+    """Construct a minimal OpenAIChatAgent for testing."""
+    with patch("src.services.agent_service.openai_chat_agent.ChatOpenAI"):
+        agent = OpenAIChatAgent(
+            temperature=0.7,
+            top_p=0.9,
+            openai_api_key="test-key",
+            model_name="gpt-4o",
+            mcp_config=mcp_config,
+        )
+    agent.agent = MagicMock()
+    agent._personas = {}
+    return agent
+
+
+class TestMCPLifecycle:
+    async def test_initialize_async_no_mcp_config(self):
+        """Agent initializes correctly when mcp_config is None."""
+        agent = make_agent(mcp_config=None)
+
+        with (
+            patch(
+                "src.services.agent_service.openai_chat_agent._load_personas",
+                return_value={},
+            ),
+            patch(
+                "src.services.service_manager.get_mongo_client",
+                return_value=None,
+            ),
+            patch(
+                "src.services.service_manager.get_user_profile_service",
+                return_value=None,
+            ),
+            patch(
+                "src.services.agent_service.tools.registry.ToolRegistry"
+            ) as mock_registry,
+            patch(
+                "src.services.agent_service.openai_chat_agent.create_agent"
+            ) as mock_create_agent,
+        ):
+            mock_registry.return_value.get_enabled_tools.return_value = []
+            mock_create_agent.return_value = MagicMock()
+
+            await agent.initialize_async()
+
+        assert agent._mcp_client is None
+        assert agent._mcp_tools == []
+
+    async def test_initialize_async_mcp_server_failure_graceful_degradation(self):
+        """Agent continues without MCP tools when MCP server fails to start."""
+        agent = make_agent(
+            mcp_config={"bad-server": {"command": "nonexistent", "transport": "stdio"}}
+        )
+
+        with (
+            patch(
+                "src.services.agent_service.openai_chat_agent._load_personas",
+                return_value={},
+            ),
+            patch(
+                "src.services.agent_service.openai_chat_agent.MultiServerMCPClient"
+            ) as mock_mcp_cls,
+            patch(
+                "src.services.service_manager.get_mongo_client",
+                return_value=None,
+            ),
+            patch(
+                "src.services.service_manager.get_user_profile_service",
+                return_value=None,
+            ),
+            patch(
+                "src.services.agent_service.tools.registry.ToolRegistry"
+            ) as mock_registry,
+            patch(
+                "src.services.agent_service.openai_chat_agent.create_agent"
+            ) as mock_create_agent,
+        ):
+            mock_mcp_instance = MagicMock()
+            mock_mcp_instance.__aenter__ = AsyncMock(
+                side_effect=RuntimeError("Server failed to start")
+            )
+            mock_mcp_cls.return_value = mock_mcp_instance
+            mock_registry.return_value.get_enabled_tools.return_value = []
+            mock_create_agent.return_value = MagicMock()
+
+            await agent.initialize_async()
+
+        # Graceful degradation: no client, no tools, agent still created
+        assert agent._mcp_client is None
+        assert agent._mcp_tools == []
+        assert agent.agent is not None
+
+    async def test_cleanup_async_no_mcp_client_is_safe(self):
+        """cleanup_async() must not raise when no MCP client exists."""
+        agent = make_agent(mcp_config=None)
+        assert agent._mcp_client is None
+
+        # Must not raise
+        await agent.cleanup_async()
+
+        assert agent._mcp_client is None
+
+    async def test_cleanup_async_closes_running_client(self):
+        """cleanup_async() calls __aexit__ and clears the client reference."""
+        agent = make_agent(mcp_config=None)
+
+        mock_client = MagicMock()
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        agent._mcp_client = mock_client
+
+        await agent.cleanup_async()
+
+        mock_client.__aexit__.assert_awaited_once_with(None, None, None)
+        assert agent._mcp_client is None
+
+    async def test_cleanup_async_called_twice_is_safe(self):
+        """Calling cleanup_async() twice must not raise."""
+        agent = make_agent(mcp_config=None)
+
+        mock_client = MagicMock()
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        agent._mcp_client = mock_client
+
+        await agent.cleanup_async()
+        await agent.cleanup_async()  # second call: _mcp_client is None, must be safe
+
+        assert agent._mcp_client is None

--- a/tests/services/agent_service/test_mcp_lifecycle.py
+++ b/tests/services/agent_service/test_mcp_lifecycle.py
@@ -1,9 +1,9 @@
-"""Tests for MCP client lifecycle in OpenAIChatAgent.
+"""Tests for MCP tool loading in OpenAIChatAgent.
 
 Covers:
 - Agent initializes correctly with mcp_config=None (no MCP)
-- Agent gracefully degrades when MCP server fails to start
-- cleanup_async() is safe to call when no MCP client exists
+- Agent gracefully degrades when get_tools() raises
+- Agent loads tools when get_tools() succeeds
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,9 +26,9 @@ def make_agent(mcp_config: dict | None = None) -> OpenAIChatAgent:
     return agent
 
 
-class TestMCPLifecycle:
+class TestMCPToolLoading:
     async def test_initialize_async_no_mcp_config(self):
-        """Agent initializes correctly when mcp_config is None."""
+        """Agent initializes correctly when mcp_config is None — no tools loaded."""
         agent = make_agent(mcp_config=None)
 
         with (
@@ -56,11 +56,10 @@ class TestMCPLifecycle:
 
             await agent.initialize_async()
 
-        assert agent._mcp_client is None
         assert agent._mcp_tools == []
 
-    async def test_initialize_async_mcp_server_failure_graceful_degradation(self):
-        """Agent continues without MCP tools when MCP server fails to start."""
+    async def test_initialize_async_get_tools_raises_graceful_degradation(self):
+        """Agent continues without MCP tools when get_tools() raises."""
         agent = make_agent(
             mcp_config={"bad-server": {"command": "nonexistent", "transport": "stdio"}}
         )
@@ -89,7 +88,7 @@ class TestMCPLifecycle:
             ) as mock_create_agent,
         ):
             mock_mcp_instance = MagicMock()
-            mock_mcp_instance.__aenter__ = AsyncMock(
+            mock_mcp_instance.get_tools = AsyncMock(
                 side_effect=RuntimeError("Server failed to start")
             )
             mock_mcp_cls.return_value = mock_mcp_instance
@@ -98,43 +97,48 @@ class TestMCPLifecycle:
 
             await agent.initialize_async()
 
-        # Graceful degradation: no client, no tools, agent still created
-        assert agent._mcp_client is None
+        # Graceful degradation: no tools, agent still created
         assert agent._mcp_tools == []
         assert agent.agent is not None
 
-    async def test_cleanup_async_no_mcp_client_is_safe(self):
-        """cleanup_async() must not raise when no MCP client exists."""
-        agent = make_agent(mcp_config=None)
-        assert agent._mcp_client is None
+    async def test_initialize_async_get_tools_succeeds(self):
+        """Agent loads tools when get_tools() returns successfully."""
+        agent = make_agent(
+            mcp_config={"my-server": {"command": "some-cmd", "transport": "stdio"}}
+        )
+        fake_tool = MagicMock()
+        fake_tool.name = "fake_tool"
 
-        # Must not raise
-        await agent.cleanup_async()
+        with (
+            patch(
+                "src.services.agent_service.openai_chat_agent._load_personas",
+                return_value={},
+            ),
+            patch(
+                "src.services.agent_service.openai_chat_agent.MultiServerMCPClient"
+            ) as mock_mcp_cls,
+            patch(
+                "src.services.service_manager.get_mongo_client",
+                return_value=None,
+            ),
+            patch(
+                "src.services.service_manager.get_user_profile_service",
+                return_value=None,
+            ),
+            patch(
+                "src.services.agent_service.tools.registry.ToolRegistry"
+            ) as mock_registry,
+            patch(
+                "src.services.agent_service.openai_chat_agent.create_agent"
+            ) as mock_create_agent,
+        ):
+            mock_mcp_instance = MagicMock()
+            mock_mcp_instance.get_tools = AsyncMock(return_value=[fake_tool])
+            mock_mcp_cls.return_value = mock_mcp_instance
+            mock_registry.return_value.get_enabled_tools.return_value = []
+            mock_create_agent.return_value = MagicMock()
 
-        assert agent._mcp_client is None
+            await agent.initialize_async()
 
-    async def test_cleanup_async_closes_running_client(self):
-        """cleanup_async() calls __aexit__ and clears the client reference."""
-        agent = make_agent(mcp_config=None)
-
-        mock_client = MagicMock()
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        agent._mcp_client = mock_client
-
-        await agent.cleanup_async()
-
-        mock_client.__aexit__.assert_awaited_once_with(None, None, None)
-        assert agent._mcp_client is None
-
-    async def test_cleanup_async_called_twice_is_safe(self):
-        """Calling cleanup_async() twice must not raise."""
-        agent = make_agent(mcp_config=None)
-
-        mock_client = MagicMock()
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        agent._mcp_client = mock_client
-
-        await agent.cleanup_async()
-        await agent.cleanup_async()  # second call: _mcp_client is None, must be safe
-
-        assert agent._mcp_client is None
+        assert agent._mcp_tools == [fake_tool]
+        assert agent.agent is not None

--- a/tests/services/agent_service/tools/test_registry.py
+++ b/tests/services/agent_service/tools/test_registry.py
@@ -75,7 +75,7 @@ class TestToolRegistryShell:
         tools = registry.get_enabled_tools()
         shell_tool = tools[0]
         result = shell_tool._run("rm -rf /")
-        assert "not allowed" in result.lower()
+        assert "not permitted" in result.lower() or "not allowed" in result.lower()
 
     def test_shell_tool_allows_whitelisted_command(self):
         config = {
@@ -122,6 +122,63 @@ class TestToolRegistryWebSearch:
         }
         registry = ToolRegistry(tool_config=config)
         assert registry.get_enabled_tools() == []
+
+
+class TestShellInjectionBlocked:
+    """Verify shell injection bypass attempts are rejected."""
+
+    def _shell_tool(self):
+        config = {
+            "builtin": {
+                "shell": {
+                    "enabled": True,
+                    "allowed_commands": ["ls"],
+                },
+            }
+        }
+        from src.services.agent_service.tools.registry import ToolRegistry
+
+        return ToolRegistry(tool_config=config).get_enabled_tools()[0]
+
+    def test_blocks_semicolon_chaining(self):
+        result = self._shell_tool()._run("ls; rm -rf /")
+        assert (
+            "disallowed" in result.lower()
+            or "not permitted" in result.lower()
+            or "not allowed" in result.lower()
+        )
+
+    def test_blocks_ampersand_chaining(self):
+        result = self._shell_tool()._run("ls && cat /etc/passwd")
+        assert (
+            "disallowed" in result.lower()
+            or "not permitted" in result.lower()
+            or "not allowed" in result.lower()
+        )
+
+    def test_blocks_pipe(self):
+        result = self._shell_tool()._run("ls | xargs rm")
+        assert (
+            "disallowed" in result.lower()
+            or "not permitted" in result.lower()
+            or "not allowed" in result.lower()
+        )
+
+    def test_blocks_command_substitution(self):
+        result = self._shell_tool()._run("ls $(whoami)")
+        assert (
+            "disallowed" in result.lower()
+            or "not permitted" in result.lower()
+            or "not allowed" in result.lower()
+        )
+
+    def test_blocks_empty_command(self):
+        result = self._shell_tool()._run("")
+        assert "empty" in result.lower()
+
+    def test_blocks_whitespace_only_command(self):
+        result = self._shell_tool()._run("   ")
+        assert "empty" in result.lower()
 
 
 class TestToolRegistryMultiple:

--- a/tests/services/agent_service/tools/test_registry.py
+++ b/tests/services/agent_service/tools/test_registry.py
@@ -1,0 +1,142 @@
+"""Tests for ToolRegistry and builtin tool wrappers."""
+
+from src.services.agent_service.tools.registry import ToolRegistry
+
+
+class TestToolRegistryEmpty:
+    def test_returns_empty_list_when_no_config(self):
+        registry = ToolRegistry(tool_config=None)
+        assert registry.get_enabled_tools() == []
+
+    def test_returns_empty_list_when_builtin_missing(self):
+        registry = ToolRegistry(tool_config={})
+        assert registry.get_enabled_tools() == []
+
+    def test_returns_empty_list_when_all_disabled(self):
+        config = {
+            "builtin": {
+                "filesystem": {"enabled": False, "root_dir": "/tmp"},
+                "shell": {"enabled": False, "allowed_commands": ["ls"]},
+                "web_search": {"enabled": False},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        assert registry.get_enabled_tools() == []
+
+
+class TestToolRegistryFilesystem:
+    def test_returns_filesystem_tools_when_enabled(self):
+        config = {
+            "builtin": {
+                "filesystem": {"enabled": True, "root_dir": "/tmp/agent-workspace"},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        tools = registry.get_enabled_tools()
+        assert len(tools) > 0
+        tool_names = [t.name for t in tools]
+        assert any("file" in n or "directory" in n or "list" in n for n in tool_names)
+
+    def test_filesystem_disabled_returns_empty(self):
+        config = {
+            "builtin": {
+                "filesystem": {"enabled": False, "root_dir": "/tmp"},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        assert registry.get_enabled_tools() == []
+
+
+class TestToolRegistryShell:
+    def test_returns_shell_tool_when_enabled(self):
+        config = {
+            "builtin": {
+                "shell": {
+                    "enabled": True,
+                    "allowed_commands": ["ls", "cat"],
+                },
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        tools = registry.get_enabled_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "terminal"
+
+    def test_shell_tool_blocks_disallowed_command(self):
+        config = {
+            "builtin": {
+                "shell": {
+                    "enabled": True,
+                    "allowed_commands": ["ls"],
+                },
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        tools = registry.get_enabled_tools()
+        shell_tool = tools[0]
+        result = shell_tool._run("rm -rf /")
+        assert "not allowed" in result.lower()
+
+    def test_shell_tool_allows_whitelisted_command(self):
+        config = {
+            "builtin": {
+                "shell": {
+                    "enabled": True,
+                    "allowed_commands": ["echo"],
+                },
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        tools = registry.get_enabled_tools()
+        shell_tool = tools[0]
+        result = shell_tool._run("echo hello")
+        assert "hello" in result
+
+    def test_shell_disabled_returns_empty(self):
+        config = {
+            "builtin": {
+                "shell": {"enabled": False, "allowed_commands": ["ls"]},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        assert registry.get_enabled_tools() == []
+
+
+class TestToolRegistryWebSearch:
+    def test_returns_search_tool_when_enabled(self):
+        config = {
+            "builtin": {
+                "web_search": {"enabled": True},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        tools = registry.get_enabled_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "duckduckgo_search"
+
+    def test_web_search_disabled_returns_empty(self):
+        config = {
+            "builtin": {
+                "web_search": {"enabled": False},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        assert registry.get_enabled_tools() == []
+
+
+class TestToolRegistryMultiple:
+    def test_combines_all_enabled_tools(self):
+        config = {
+            "builtin": {
+                "filesystem": {"enabled": True, "root_dir": "/tmp"},
+                "shell": {"enabled": True, "allowed_commands": ["ls"]},
+                "web_search": {"enabled": True},
+            }
+        }
+        registry = ToolRegistry(tool_config=config)
+        tools = registry.get_enabled_tools()
+        # filesystem gives multiple tools, shell gives 1, web_search gives 1
+        assert len(tools) >= 3
+        tool_names = [t.name for t in tools]
+        assert "terminal" in tool_names
+        assert "duckduckgo_search" in tool_names

--- a/uv.lock
+++ b/uv.lock
@@ -605,6 +605,33 @@ wheels = [
 ]
 
 [[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
+]
+
+[[package]]
+name = "ddgs"
+version = "9.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/23/d792684ee325a5965ed9af3fde30af456ca6367529bf137d7582735b3708/ddgs-9.13.0.tar.gz", hash = "sha256:b0b9db0895917d4c6dda54b730cdb1a27501ae4350e8b48182b9c3e87b9dbd84", size = 37311, upload-time = "2026-04-06T15:00:38.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/8d/ea7dba889bc5520f7a40ef191a48b62e59a265f0fdb5973046513f9e94f4/ddgs-9.13.0-py3-none-any.whl", hash = "sha256:3182c2853e7b0cfc030f50cbebee382fa44d6dd258fa55e5d24789ae1e4c6a93", size = 46437, upload-time = "2026-04-06T15:00:36.901Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -647,11 +674,14 @@ dependencies = [
     { name = "aiohttp" },
     { name = "basedpyright" },
     { name = "cachetools" },
+    { name = "ddgs" },
+    { name = "duckduckgo-search" },
     { name = "fast-bunkai" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jupyter" },
     { name = "langchain" },
+    { name = "langchain-community" },
     { name = "langchain-mcp-adapters" },
     { name = "langchain-neo4j" },
     { name = "langchain-openai" },
@@ -713,6 +743,8 @@ requires-dist = [
     { name = "basedpyright", specifier = ">=1.39.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.10.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
+    { name = "ddgs", specifier = ">=9.13.0" },
+    { name = "duckduckgo-search", specifier = ">=8.1.1" },
     { name = "fast-bunkai", specifier = ">=0.1.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -721,6 +753,7 @@ requires-dist = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "langchain", specifier = ">=1.2.12" },
+    { name = "langchain-community", specifier = ">=0.4.1" },
     { name = "langchain-mcp-adapters", specifier = ">=0.2.2" },
     { name = "langchain-neo4j", specifier = ">=0.7.0" },
     { name = "langchain-openai", specifier = ">=1.1.11" },
@@ -803,6 +836,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "duckduckgo-search"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/ef/07791a05751e6cc9de1dd49fb12730259ee109b18e6d097e25e6c32d5617/duckduckgo_search-8.1.1.tar.gz", hash = "sha256:9da91c9eb26a17e016ea1da26235d40404b46b0565ea86d75a9f78cc9441f935", size = 22868, upload-time = "2025-07-06T15:30:59.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/72/c027b3b488b1010cf71670032fcf7e681d44b81829d484bb04e31a949a8d/duckduckgo_search-8.1.1-py3-none-any.whl", hash = "sha256:f48adbb06626ee05918f7e0cef3a45639e9939805c4fc179e68c48a12f1b5062", size = 18932, upload-time = "2025-07-06T15:30:58.339Z" },
 ]
 
 [[package]]
@@ -1663,6 +1710,29 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-community"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "httpx-sse" },
+    { name = "langchain-classic" },
+    { name = "langchain-core" },
+    { name = "langsmith" },
+    { name = "numpy" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/97/a03585d42b9bdb6fbd935282d6e3348b10322a24e6ce12d0c99eb461d9af/langchain_community-0.4.1.tar.gz", hash = "sha256:f3b211832728ee89f169ddce8579b80a085222ddb4f4ed445a46e977d17b1e85", size = 33241144, upload-time = "2025-10-27T15:20:32.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/a4/c4fde67f193401512337456cabc2148f2c43316e445f5decd9f8806e2992/langchain_community-0.4.1-py3-none-any.whl", hash = "sha256:2135abb2c7748a35c84613108f7ebf30f8505b18c3c18305ffaecfc7651f6c6a", size = 2533285, upload-time = "2025-10-27T15:20:30.767Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.2.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1934,6 +2004,68 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/42/149c7747977db9d68faee960c1a3391eb25e94d4bb677f8e2df8328e4098/lxml-6.0.3.tar.gz", hash = "sha256:a1664c5139755df44cab3834f4400b331b02205d62d3fdcb1554f63439bf3372", size = 4237567, upload-time = "2026-04-09T14:39:09.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/a6/2cdc9c5a634b1b890927f968febc2474fa3eb6fed99db82ea3c008bbbda4/lxml-6.0.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:83c1d75e9d124ab82a4ddaf59135112f0dc49526b47355e5928ae6126a68e236", size = 8559579, upload-time = "2026-04-09T14:35:35.644Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3c/adfbcdab17f89f72e069c5df5661c81e0511e3cdb353550f778e9ffaa08e/lxml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b683665d0287308adafc90a5617a51a508d8af8c7040693693bb333b5f4474fe", size = 4617332, upload-time = "2026-04-09T14:35:38.901Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d4/ee1a5c734a5ad79024fa85808f3efc18d5733813141e2bb2726a7d9d8bea/lxml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ed31e5852cd938704bc6c7a3822cbf84c7fa00ebfa914a1b4e2392d44f45bdfb", size = 4922821, upload-time = "2026-04-09T14:35:41.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1f/87efcc0b93ba4f95303ec8f80164f3c50db20a3a5612a285133f9ad6cb7e/lxml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8922a30704a4421d69a19e0499db5861da686c0bccc3a79cf3946e3155cf25f9", size = 5081226, upload-time = "2026-04-09T14:35:44.02Z" },
+    { url = "https://files.pythonhosted.org/packages/65/8b/fd0fadd9ec8a6ac9d694014ccdb9504e28705abb2e08c9ca23c609020325/lxml-6.0.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a1adb0e220cb8691202ba9d97646a06292657a122df4b92733861d42f7cf4d2", size = 4992884, upload-time = "2026-04-09T14:35:46.769Z" },
+    { url = "https://files.pythonhosted.org/packages/68/75/2fb0e534225214c6386496b7847195d7297b913cf563c5ccea394afc346b/lxml-6.0.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:821fd53699eb498990c915ba955a392d07246454c9405e6c1d0692362503013d", size = 5613383, upload-time = "2026-04-09T14:35:49.303Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/8f560f8fb2f5f092e18ac7a13a94b77e0e5213fe7c424d12e98393dcc7d8/lxml-6.0.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04b7cedf52e125f86d0d426635e7fbe8e353d4cc272a1757888e3c072424381d", size = 5228398, upload-time = "2026-04-09T14:35:51.611Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d5/6bf993c02a0173eb5883ace61958c55c245d3daf7753fb5f931a9691b440/lxml-6.0.3-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:9d98063e6ae0da5084ec46952bb0a5ccb5e2cad168e32b4d65d1ec84e4b4ebd4", size = 5342198, upload-time = "2026-04-09T14:35:54.311Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/18/637130349ca6aa33b6dc4796732835ede5017a811c5f55763a1c468f7971/lxml-6.0.3-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:ce01ab3449015358f766a1950b3d818eedf9d4cdec3fa87e4eecaad10c0784db", size = 4699178, upload-time = "2026-04-09T14:35:56.647Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/19/239daafcc1cfa42b8aa6384509a9fd2cb1aa281679c6e8395adf9ccbc189/lxml-6.0.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d38c25bad123d6ce30bb37931d90a4e8a167cd796eeae9cd16c2bfce52718f8e", size = 5231869, upload-time = "2026-04-09T14:36:00.41Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/74/db7fcadc651b988502bed00d48acfd8b997ecb5dd52ebcc05f39bf946d9e/lxml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9b8e0779780026979f217603385995202f364adc9807bd21210d81b9f562fc4e", size = 5043669, upload-time = "2026-04-09T14:36:02.463Z" },
+    { url = "https://files.pythonhosted.org/packages/55/99/af795b579182fa04aa87fcb0bd112e22705d982f71eb53874a8d356b4091/lxml-6.0.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8c082ad2398664213a4bb5d133e2eb8bf239220b7d6688f8c8ffa9050057501f", size = 4769745, upload-time = "2026-04-09T14:36:04.716Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4d/10e652edc55d206188a1b738d1033aad3497886d34cb7f5fc753e67ecb49/lxml-6.0.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfc80c74233fe01157ab550fb12b9d07a2f1fa7c5900cefb484e3bf02e856fbc", size = 5635496, upload-time = "2026-04-09T14:36:06.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/68/95371835ec15bb46feee27b090bcabbe579f4ad04efbef08e2713bcfea16/lxml-6.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5c45bdcdc2ca6cf26fddff3faa5de7a2ed7c7f6016b3de80125313a37f972378", size = 5223564, upload-time = "2026-04-09T14:36:09.057Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a6/0a9e5b63e8959487551be5d5496bb758ed2424c77ed7b25a9b8aae3b60c6/lxml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:99457524afd384c330dc51e527976653d543ccadfa815d9f2d92c5911626e536", size = 5250124, upload-time = "2026-04-09T14:36:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/80/de3d3a790edf6d026c829fe8ccf54845058f57f8bb788e420c3b227eecef/lxml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:c8e3b8a54e65393ce1d5c7d9753fe756f0d96089e7163b20ddec3e5bb56a963e", size = 3596004, upload-time = "2026-04-09T14:36:13.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cf/43c9a5926060e39d99593921f37d7e88f129bc32ab6266b8460483abd613/lxml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:724b26a38cef98d6869d00a33cb66083bee967598e44f6a8e53f1dd283c851b0", size = 3994750, upload-time = "2026-04-09T14:36:15.686Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/b224dbc282bfef52d2e05645e405b5ed89c6391144dc09864229fe9ce88c/lxml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:f27373113fda6621e4201f529908a24c8a190c2af355aed4711dadca44db4673", size = 3657620, upload-time = "2026-04-09T14:36:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/40/b637359bacf3813f1174d15b08516020ba5beb355e04377105d561e6e00a/lxml-6.0.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8c08926678852a233bf1ef645c4d683d56107f814482f8f41b21ef2c7659790e", size = 8575318, upload-time = "2026-04-09T14:36:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/91/d5286a45202ed91f1e428e68c6e1c11bcb2b42715c48424871fc73485b05/lxml-6.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2ce76d113a7c3bf42761ec1de7ca615b0cbf9d8ae478eb1d6c20111d9c9fc098", size = 4623084, upload-time = "2026-04-09T14:36:24.015Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/7ea1af571ee13ed1e5fba007fd83cd0794723ca76a51eed0ef9513363b1f/lxml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83eca62141314d641ebe8089ffa532bbf572ea07dd6255b58c40130d06bb2509", size = 4948797, upload-time = "2026-04-09T14:36:26.662Z" },
+    { url = "https://files.pythonhosted.org/packages/82/be/3a9b8d787d9877cbe17e02ef5af2523bd14ecc177ce308397c485c56fe18/lxml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8781d812bb8efd47c35651639da38980383ff0d0c1f3269ade23e3a90799079", size = 5085983, upload-time = "2026-04-09T14:36:29.486Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2b/645abaef837b11414c81513c31b308a001fb8cd370f665c3ebc854be5ba5/lxml-6.0.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19b079e81aa3a31b523a224b0dd46da4f56e1b1e248eef9a599e5c885c788813", size = 5031039, upload-time = "2026-04-09T14:36:31.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/561f30b77e9edbb373e2b6b7203a7d6ab219c495abca219536c66f3a44b2/lxml-6.0.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6c055bafdcb53e7f9f75e22c009cd183dd410475e21c296d599531d7f03d1bf5", size = 5646718, upload-time = "2026-04-09T14:36:34.127Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ba/2a72e673d109b563c2ab77097f2f4ca64e2927d2f04836ba07aaabe1da0e/lxml-6.0.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f1594a183cee73f9a1dbfd35871c4e04b461f47eeb9bcf80f7d7856b1b136d", size = 5239360, upload-time = "2026-04-09T14:36:37.195Z" },
+    { url = "https://files.pythonhosted.org/packages/52/98/4e5a4ef87d846af90cc9c1ee2f8af2af34c221e620aad317b3a535361b93/lxml-6.0.3-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:a6380c5035598e4665272ad3fc86c96ddb2a220d4059cce5ba4b660f78346ad9", size = 5351233, upload-time = "2026-04-09T14:36:39.634Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b8/cff0af5fe48ede6b1949dc2e14171470c0c68a15789037c1fed90602b89d/lxml-6.0.3-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:143ac903fb6c9be6da613390825c8e8bb8c8d71517d43882031f6b9bc89770ef", size = 4696677, upload-time = "2026-04-09T14:36:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/6e/0b2a918fb15c30b00ff112df16c548df011db37b58d764bd17f47db74905/lxml-6.0.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4fff7d77f440378cd841e340398edf5dbefee334816efbf521bb6e31651e54e", size = 5250503, upload-time = "2026-04-09T14:36:44.417Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1b/4697918f9d4c2e643e2c59cedb37c2f3a9f76fb1217d767f6dff476813d8/lxml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:631567ffc3ddb989ccdcd28f6b9fa5aab1ec7fc0e99fe65572b006a6aad347e2", size = 5084563, upload-time = "2026-04-09T14:36:46.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8c/d7ec96246f0632773912c6556288d3b6bb6580f3a967441ca4636ddc3f73/lxml-6.0.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:38acf7171535ffa7fff1fcec8b82ebd4e55cd02e581efe776928108421accaa1", size = 4737407, upload-time = "2026-04-09T14:36:49.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0c/603e35bf77aeb28c972f39eece35e7c0f6579ff33a7bed095cc2f7f942d9/lxml-6.0.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:06b9f3ac459b4565bbaa97aa5512aa7f9a1188c662f0108364f288f6daf35773", size = 5670919, upload-time = "2026-04-09T14:36:52.231Z" },
+    { url = "https://files.pythonhosted.org/packages/92/08/6d3f188e6705cf0bfd8b5788055c7381bb3ffa786dfba9fa0b0ed5778506/lxml-6.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2773dbe2cedee81f2769bd5d24ceb4037706cf032e1703513dd0e9476cd9375f", size = 5237771, upload-time = "2026-04-09T14:36:55.286Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/01639533b90e9ff622909c113df2ab2dbdd1d78540eb153d13b66a9c96ba/lxml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:30c437d8bb9a9a9edff27e85b694342e47a26a6abc249abe00584a4824f9d80d", size = 5263862, upload-time = "2026-04-09T14:36:58.247Z" },
+    { url = "https://files.pythonhosted.org/packages/06/0e/bd1157d7b09d1f5e1d580c124203cee656130a3f8908365760a593b21daf/lxml-6.0.3-cp314-cp314-win32.whl", hash = "sha256:1b60a3a1205f869bd47874787c792087174453b1a869db4837bf5b3ff92be017", size = 3656378, upload-time = "2026-04-09T14:37:47.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cc/d50cbce8cd5687670868bea33bbeefa0866c5e5d02c5e11c4a04c79fc45e/lxml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:5b6913a68d98c58c673667c864500ba31bc9b0f462effac98914e9a92ebacd2e", size = 4062518, upload-time = "2026-04-09T14:37:49.911Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c7/ece11a1e51390502894838aa384e9f98af7bef4d6806a927197153a16972/lxml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:1b36a3c73f2a6d9c2bfae78089ca7aedae5c2ee5fd5214a15f00b2f89e558ba7", size = 3741064, upload-time = "2026-04-09T14:37:52.185Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ae/918d7f89635fb6456cd732c12246c0e504dd9c49e8006f3593c9ecdb90ff/lxml-6.0.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:239e9a6be3a79c03ec200d26f7bb17a4414704a208059e20050bf161e2d8848a", size = 8826590, upload-time = "2026-04-09T14:37:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cf/bda0ae583758704719976b9ea69c8b089fa5f92e49683e517386539b21cf/lxml-6.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:16e5cbaa1a6351f2abefa4072e9aac1f09103b47fe7ab4496d54e5995b065162", size = 4735028, upload-time = "2026-04-09T14:37:03.602Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0e/3bfb18778c6f73c7ead2d49a256501fa3052888b899826f5d1df1fbdf83b/lxml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89f8746c206d8cf2c167221831645d6cc2b24464afd9c428a5eb3fd34c584eb1", size = 4969184, upload-time = "2026-04-09T14:37:05.914Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e6/796c77751a682d6d1bb9aa3fe43851b41a21b0377100e246a4a83a81d668/lxml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5d559a84b2fd583e5bcf8ec4af1ec895f98811684d5fbd6524ea31a04f92d4ad", size = 5103548, upload-time = "2026-04-09T14:37:08.605Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/a02aee214f657f29d4690d88161de8ffb8f1b5139e792bae313b9479e317/lxml-6.0.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7966fbce2d18fde579d5593933d36ad98cc7c8dc7f2b1916d127057ce0415062", size = 5027775, upload-time = "2026-04-09T14:37:11.283Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e5/65dd25f2c366879d696d1c720af9a96fa0969d2d135a27b6140222fc6f68/lxml-6.0.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a1f258e6aa0e6eda2c1199f5582c062c96c7d4a28d96d0c4daa79e39b3f2a764", size = 5595348, upload-time = "2026-04-09T14:37:13.618Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/1f/2f0e80d7fd2ad9755d771af4ad46ea14bf871bc5a1d2d365a3f948940ddf/lxml-6.0.3-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:738aef404c862d2c3cd951364ee7175c9d50e8290f5726611c4208c0fba8d186", size = 5224217, upload-time = "2026-04-09T14:37:16.519Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/28/e1aaeee7d6a4c9f24a3e4535a4e19ce64b99eefbe7437d325b61623b1817/lxml-6.0.3-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:5c35e5c3ed300990a46a144d3514465713f812b35dacfa83e928c60db7c90af7", size = 5312245, upload-time = "2026-04-09T14:37:19.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ac/9633cb919124473e03c62862b0494bf0e1705f902fbd9627be4f648bddfb/lxml-6.0.3-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:4ff774b43712b0cf40d9888a5494ca39aefe990c946511cc947b9fddcf74a29b", size = 4637952, upload-time = "2026-04-09T14:37:21.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/aa/135baeea457d41989bafa78e437fe3a370c793aab0d8fb3da73ccae10095/lxml-6.0.3-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d20af2784c763928d0d0879cbc5a3739e4d81eefa0d68962d3478bff4c13e644", size = 5232782, upload-time = "2026-04-09T14:37:24.6Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/d05183ac8440cbc4c6fa386edb7ba9718bee4f097e58485b1cd1f9479d56/lxml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fdb7786ebefaa0dad0d399dfeaf146b370a14591af2f3aea59e06f931a426678", size = 5083889, upload-time = "2026-04-09T14:37:27.432Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/58/e9fda8fb82775491ad0290c7b17252f944b6c3a6974cd820d65910690351/lxml-6.0.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c71a387ea133481e725079cff22de45593bf0b834824de22829365ab1d2386c9", size = 4758658, upload-time = "2026-04-09T14:37:29.81Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/32/4aae9f004f79f9d200efd8343809cfe46077f8e5bd58f08708c320a20fcd/lxml-6.0.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:841b89fc3d910d61c7c267db6bb7dc3a8b3dac240edb66220fcdf96fe70a0552", size = 5619494, upload-time = "2026-04-09T14:37:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/49/407fa9e3c91e7c6d0762eaeedd50d4695bcd26db817e933ca689eb1f3df4/lxml-6.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:ac2d6cdafa29672d6a604c641bf67ace3fd0735ec6885501a94943379219ddbf", size = 5228386, upload-time = "2026-04-09T14:37:36.058Z" },
+    { url = "https://files.pythonhosted.org/packages/99/92/39982f818acbb1dd67dd5d20c2a06bcb9f1f3b9a8ff0021e367904f82417/lxml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:609bf136a7339aeca2bd4268c7cd190f33d13118975fe9964eda8e5138f42802", size = 5247973, upload-time = "2026-04-09T14:37:38.836Z" },
+    { url = "https://files.pythonhosted.org/packages/66/68/fcdbb78c8cda81a86e17b31abf103b7e474e474a09fb291a99e7a9b43eb8/lxml-6.0.3-cp314-cp314t-win32.whl", hash = "sha256:bf98f5f87f6484302e7cce4e2ca5af43562902852063d916c3e2f1c115fdce60", size = 3896249, upload-time = "2026-04-09T14:37:41.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/6292681ac4a4223b700569ce98f71662cb07c5a3ade4f346f5f0d5c574cf/lxml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:d3d65e511e4e656ec67b472110f7a72cbf8547ca15f76fe74cffa4e97412a064", size = 4391091, upload-time = "2026-04-09T14:37:43.357Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/a0f486360a6f1b36fd2f5eb62d037652bef503d82b6f853aee6664cdfcac/lxml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:cbc7ce67f85b92db97c92219985432be84dc1ba9a028e68c6933e89551234df2", size = 3816374, upload-time = "2026-04-09T14:37:45.532Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1983,6 +2115,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "marshmallow"
+version = "3.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
 ]
 
 [[package]]
@@ -2629,6 +2773,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/7b/ed8be2c72c6c5f8cf3c41dc9b4b94aeb37efcc8990635724abf067e7f2aa/primp-1.2.2.tar.gz", hash = "sha256:ab6150eebfea8bb9a129eb2c43296fa6acde949bc4a9ac70cf3279ffbfdac88f", size = 166291, upload-time = "2026-04-03T07:11:28.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6b/be0766093587e88e0cf7a4b3dd04da09a1ce282b8b0c0c78a6c59312bb62/primp-1.2.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7b5b1ae100600351266685bef5f73f906dc4d67a0234ddca3a639df360fae4f4", size = 4378451, upload-time = "2026-04-03T07:11:15.557Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/6e/3dea83a569d9b1352c293589e33ec3a86f3892c5947a290e6195ccbc3fc4/primp-1.2.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0b00c906049255c6bbe87a9846d14f3e76886fcc38c1507cc833aa093fb2e680", size = 4041439, upload-time = "2026-04-03T07:11:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/bb/87511a35fe21b33de82550db84154859d71b93020f04f6839f003fc7f4cb/primp-1.2.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f9d778e1b64d17270d3e6d652cf0b8e5c864df9e3caa69665dc99904a57f83d", size = 4319301, upload-time = "2026-04-03T07:11:02.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/1e/18ec7c262f87a4a409ba003c902ce969a4025322c6546b9a3ea68824d7f5/primp-1.2.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e8c34fcbe1c10f7201d9004502c5af784255accbe518faea91f6989b6f68b2e5", size = 3914005, upload-time = "2026-04-03T07:11:26.891Z" },
+    { url = "https://files.pythonhosted.org/packages/38/be/b24293cc6525ed5179a155add307c3a7c93703bf8778f5a2d2fbf78354b5/primp-1.2.2-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:20f71d692ed234364da9c7ad9013bd0049b58410e9e28c4c64f0475c6254c1d3", size = 4163586, upload-time = "2026-04-03T07:11:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9c/3f3d06c085a6fa9cea89d267a5f83a598f7c60dd2510e5eb9119edfa93ad/primp-1.2.2-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d78518ab13b2d63ecc453e7edf33b533492e76b24eb1bfdf744c0ca5d60d49b", size = 4450010, upload-time = "2026-04-03T07:11:05.615Z" },
+    { url = "https://files.pythonhosted.org/packages/18/87/df4159d0c40ca42220c99e3f38d4c4806f20f1520ea7259bae00ab781250/primp-1.2.2-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbda1348329778942a6bee8e12f90e56985bcd414b5ee80c2e2413e1fcbd2ee2", size = 4348650, upload-time = "2026-04-03T07:10:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/07/08c337f7800010393b6a2e11669ac923c8572fa5ce9d3f4164c5c5a7475b/primp-1.2.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fa354bf08879662acbc3c141eb365d9bb7a768aee06231ee6af693d37c6000b", size = 4556701, upload-time = "2026-04-03T07:11:22.784Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c7/13b1c88499fa3b531c93ef6384580539cbd4d0ff12d1abcd8e2acf30b6e7/primp-1.2.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ee1225c9688987fb032c00bf241ca10baf371d5b4b7b812bf18468e2f9408b06", size = 4482096, upload-time = "2026-04-03T07:10:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/02/df/1fc8f76ba2893c838e224739e02a200f15a5a483c167587d70d0054a4c00/primp-1.2.2-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e2d9d19536c6bdf62c08070825d199938f744a9ad85c08233c264f7eac8c7531", size = 4148763, upload-time = "2026-04-03T07:11:06.778Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f9/dd33612503e5447d50504fe1aaed3eeeaf718d2a7e30227baf6a3f3f1b58/primp-1.2.2-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:4e670106e9d54ec5d73b5a1c4ebbb77e1c9b0fcc29f6661d983863d031db3c66", size = 4294449, upload-time = "2026-04-03T07:11:18.491Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/45/3c6d2901becc10d7c68f14c91973efe50da0dc5fe65b7d14f12b18f4f248/primp-1.2.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55d7bfb8555f5a8d8d8fcb3bdc2b08be0372f2f60ad5f7c8fb3b30f8ab7558bc", size = 4804400, upload-time = "2026-04-03T07:11:29.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/12/5db91660965772af39572829195e653b6ab2472f378346045bddf9d3d630/primp-1.2.2-cp310-abi3-win32.whl", hash = "sha256:387d6511b398678eebc5f083b1ba702da201a8719f3e61795946bf7112e3bcfe", size = 3525833, upload-time = "2026-04-03T07:11:30.517Z" },
+    { url = "https://files.pythonhosted.org/packages/47/41/15a26263848143adfe06c2bd73373df9cb4fae3852399be95335000fcff9/primp-1.2.2-cp310-abi3-win_amd64.whl", hash = "sha256:7831385b76618ec4916c3b5d11a8630b406dad042fa3eb043d1f6aca6a0c825e", size = 3900541, upload-time = "2026-04-03T07:11:33.982Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/31/beb366bf222771e0c7062efd13d26b7a7f9fb1ba42c2c67d7deccec99772/primp-1.2.2-cp310-abi3-win_arm64.whl", hash = "sha256:5002d61c78ab12a63cbc91ed2e195fbb6d9098a41b736ea680192ca9b2986e59", size = 3887324, upload-time = "2026-04-03T07:11:12.593Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ad/428427c1963e40ea206c255bf8e4f1186dd9489936a1f6c313608d8f0920/primp-1.2.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:13956a4ca00f5c6e3192bd3202f26f54711ca6e35533dea2518236a08bc2ecec", size = 4362827, upload-time = "2026-04-03T07:11:11.369Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/50/d16a911f19bfc9379229289bd1367b6cc20c7206232c30fb2bf6f04997f3/primp-1.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cfb43e112191ca2abd152f6895c08d6463572683070e0e96134c5f6c64449800", size = 4038456, upload-time = "2026-04-03T07:10:59.087Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/cb/7de01f6cde950d8066f78d9b8f60c7014f4f54f00e5d24329b0f7db8652c/primp-1.2.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86b6b61443675e906064d839e279acdb731e2ddd5b0aa5d4cc12d7d7c58cbfdd", size = 4312185, upload-time = "2026-04-03T07:11:09.571Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/80/e1e76238935a49aa58f5ac258041f3e673056899c9749f0955b19065af39/primp-1.2.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c087296ee90d95fcb733f6c53f6d31a25faa8f3a7a2b787622804a0d8672b78", size = 3909719, upload-time = "2026-04-03T07:11:00.71Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ac/b60259be9d0348cb55012aeab2b39eb9ce858e822288420eabbaca11b082/primp-1.2.2-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a4509820cc6815d97737abff4bfb5b5543d5d9817d08f57d6b4b85bc9716280", size = 4164545, upload-time = "2026-04-03T07:11:21.188Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d1/64f642bd5754c3acf848987f0cf21fc0f429043d288bb5b8519fad47524d/primp-1.2.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:68f757812e317f8ad46d329ae3798cf3867876d7b44359f58f62c5067b3cd841", size = 4438427, upload-time = "2026-04-03T07:11:31.626Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/c44b3e001452a88444ad2a6d64f8f0f25eb399a277b44cd45d9ab6ec5810/primp-1.2.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a32f578b29954c697ceca781a2a8cf0842ac25a87cd95e9fe3f6b4fc916953c3", size = 4334964, upload-time = "2026-04-03T07:11:24.061Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/10/6b38c0c94d2b5307b7725597b697217d7676d55fd3079afcec0eddbd75e8/primp-1.2.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f50c14684a49554f6fc292796644c5414d7c1e6e8056ec1337920d18e3c86de4", size = 4550519, upload-time = "2026-04-03T07:11:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3d/04d21c16415a82d89f45989bf7216d456eb79268f8b94baa2209fa1ab4b0/primp-1.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bfb74f5c201fb38453ce92bf6bd0af2ff925977642aff4a90d00b54663b1ddc1", size = 4478749, upload-time = "2026-04-03T07:11:36.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b3/52360d0b6051fb712b0ba7f4e3f1ab15997405e62ddf47306dc5f0a290ac/primp-1.2.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db96c7306680acc1b8b777cdfcdfefa7d9ff973d6f8f26759522bfee98f80b7", size = 4148483, upload-time = "2026-04-03T07:10:54.374Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/db/049657a1a731869e3243da4802b58c48142629e0a8cfb6af735f783358d3/primp-1.2.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:5e98582300230ca702080f81789e6839c6c552feecd183383eb515a693ce1122", size = 4287608, upload-time = "2026-04-03T07:11:04.233Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/76/8ea898e77f499293a194d3419579c721ff05704a5b4ea05cc65afd9c99e5/primp-1.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7bbb449ec4705b91a9846ef898fa5b1b7afe7aabdd99e367e2c76690db4b6a9d", size = 4797147, upload-time = "2026-04-03T07:11:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c3/3898437570bb043ae2af763c5951eee8b1a7fe8b225216e78bfe306c2ff5/primp-1.2.2-cp314-cp314t-win32.whl", hash = "sha256:75be400f178f4e97acd757e27cc2c71948f080cdc52e5474cb1e1e18b5b832d6", size = 3522857, upload-time = "2026-04-03T07:11:08.284Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ea/64c4510e63cc2213afa4938599d996de51e32ba31b62986045f7d32ebb58/primp-1.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:6dbfa3f2a56508bb24aa6b7d1c55cdc26c9d2dd08ac210c9f2affd7be0cdd8cf", size = 3899017, upload-time = "2026-04-03T07:11:14.406Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d1/51cdcb9f4ae6d6a823a8f99cfd1db0247dea0e8e0d6962799da8c95006bc/primp-1.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:188a9ac1435447ebca26557a1d80a87b3cd2c8466bce65e64eb599ee12210c78", size = 3886420, upload-time = "2026-04-03T07:11:16.996Z" },
 ]
 
 [[package]]
@@ -3920,6 +4102,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]

--- a/yaml_files/services/agent_service/openai_chat_agent.yml
+++ b/yaml_files/services/agent_service/openai_chat_agent.yml
@@ -20,3 +20,14 @@ llm_config:
 #   }
 
 # Note: configurations of memory and vocabulary manager should be set in .env files
+
+tool_config:
+  builtin:
+    filesystem:
+      enabled: false
+      root_dir: "/tmp/agent-workspace"
+    shell:
+      enabled: false
+      allowed_commands: ["ls", "cat", "grep", "ps", "date", "whoami", "pwd", "wc", "head", "tail"]
+    web_search:
+      enabled: false

--- a/yaml_files/services/agent_service/openai_chat_agent.yml
+++ b/yaml_files/services/agent_service/openai_chat_agent.yml
@@ -28,6 +28,6 @@ tool_config:
       root_dir: "/tmp/agent-workspace"
     shell:
       enabled: false
-      allowed_commands: ["ls", "cat", "grep", "ps", "date", "whoami", "pwd", "wc", "head", "tail"]
+      allowed_commands: ["ls", "cat", "ps", "date", "whoami", "pwd", "wc", "head", "tail"]
     web_search:
       enabled: false

--- a/yaml_files/services/agent_service/openai_chat_agent.yml
+++ b/yaml_files/services/agent_service/openai_chat_agent.yml
@@ -12,12 +12,17 @@ llm_config:
     support_image: True  # Enable image support
     # openai_api_key is loaded from LLM_API_KEY environment variable
 
+# MCP Server Configuration
+# Uncomment to enable MCP tool servers
 # mcp_config:
-#   "sequential-thinking": {
-#       "command": "npx",
-#       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
-#       "transport": "stdio",
-#   }
+#   "sequential-thinking":
+#     command: "npx"
+#     args: ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+#     transport: "stdio"
+#   "code-sandbox":
+#     command: "docker"
+#     args: ["run", "--rm", "-i", "--net=none", "--memory=512m", "--cpus=1", "ghcr.io/pydantic/mcp-run-python"]
+#     transport: "stdio"
 
 # Note: configurations of memory and vocabulary manager should be set in .env files
 


### PR DESCRIPTION
## Summary
- Add `ToolRegistry` with YAML config-driven tool enable/disable
- LangChain builtin tools: filesystem (ReadFile/WriteFile/ListDir), shell (command whitelist), DuckDuckGo search
- Pydantic V2 models for `ToolConfig` validation at startup
- Shell security: `shlex.split()` + `shell=False` + metacharacter rejection
- All tools disabled by default for safety

## Files
- `src/services/agent_service/tools/registry.py` — Tool registry
- `src/services/agent_service/tools/builtin/` — Filesystem, shell, search tool wrappers
- `src/configs/agent/openai_chat_agent.py` — Pydantic ToolConfig models
- `yaml_files/services/agent_service/openai_chat_agent.yml` — tool_config section
- `tests/services/agent_service/tools/test_registry.py` — 18 tests including injection bypass

## Test plan
- [x] 568 unit tests pass
- [x] Shell injection bypass tests (`;`, `&&`, `|`, `$()`) all blocked
- [x] Lint pass
- [x] Security review: shell=False, metacharacter rejection, no type:ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)