### PR TITLE
feat: fix MCP client lifecycle for langchain-mcp-adapters 0.2.2

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -210,6 +210,15 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 logger.exception("Error stopping sweep service")
 
         try:
+            from src.services import get_agent_service
+
+            agent_svc = get_agent_service()
+            if agent_svc is not None and hasattr(agent_svc, "cleanup_async"):
+                await agent_svc.cleanup_async()
+        except Exception:
+            logger.exception("Error cleaning up agent MCP client")
+
+        try:
             from src.services.channel_service import cleanup_channel_service
 
             await cleanup_channel_service()

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -1,4 +1,3 @@
-import traceback
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
@@ -42,8 +41,8 @@ def _load_personas() -> dict[str, str]:
             for pid, p in data.get("personas", {}).items()
             if "system_prompt" in p
         }
-    except Exception as e:
-        logger.error(f"Failed to load personas.yml: {e}")
+    except Exception:
+        logger.exception("Failed to load personas.yml")
         return {}
 
 
@@ -67,7 +66,6 @@ class OpenAIChatAgent(AgentService):
         self.model_name = model_name
         self.tool_config = tool_config
         self.agent = None
-        self._mcp_client: MultiServerMCPClient | None = None
         self._mcp_tools: list = []
         self._personas: dict[str, str] = {}
         super().__init__(**kwargs)
@@ -89,18 +87,14 @@ class OpenAIChatAgent(AgentService):
         self._personas = _load_personas()
         logger.info(f"Loaded {len(self._personas)} personas: {list(self._personas)}")
 
-        # 2. Start persistent MCP client (keeps stdio subprocesses alive)
+        # 2. Load MCP tools via stateless client (langchain-mcp-adapters 0.2.2+)
         if self.mcp_config:
             try:
-                self._mcp_client = MultiServerMCPClient(self.mcp_config)
-                await self._mcp_client.__aenter__()
-                self._mcp_tools = self._mcp_client.get_tools()
-                logger.info(f"MCP client started with {len(self._mcp_tools)} tools")
-            except Exception as e:
-                logger.error(
-                    f"Failed to start MCP client, continuing without MCP tools: {e}"
-                )
-                self._mcp_client = None
+                client = MultiServerMCPClient(self.mcp_config)
+                self._mcp_tools = await client.get_tools()
+                logger.info(f"Loaded {len(self._mcp_tools)} MCP tools")
+            except Exception:
+                logger.exception("Failed to load MCP tools, continuing without")
                 self._mcp_tools = []
 
         # 3. Create single agent instance
@@ -166,15 +160,8 @@ class OpenAIChatAgent(AgentService):
         logger.info("Agent created successfully")
 
     async def cleanup_async(self) -> None:
-        """Shut down the persistent MCP client if one is running."""
-        if self._mcp_client is not None:
-            try:
-                await self._mcp_client.__aexit__(None, None, None)
-                logger.info("MCP client closed")
-            except Exception as e:
-                logger.error(f"Error closing MCP client: {e}")
-            finally:
-                self._mcp_client = None
+        """No-op: stateless MCP client requires no shutdown."""
+        logger.info("MCP cleanup: nothing to clean up (stateless client)")
 
     async def is_healthy(self) -> tuple[bool, str]:
         """Check if the agent is healthy and ready."""
@@ -185,7 +172,7 @@ class OpenAIChatAgent(AgentService):
                 continue
             return True, "Agent is healthy."
         except Exception as e:
-            logger.error(f"Health check failed: {e}")
+            logger.exception("Health check failed")
             return False, f"Health check failed: {e}"
 
     async def stream(
@@ -250,9 +237,8 @@ class OpenAIChatAgent(AgentService):
                     "content": content,
                     "new_chats": new_chats,
                 }
-        except Exception as e:
-            logger.error(f"Error in stream method: {e}")
-            traceback.print_exc()
+        except Exception:
+            logger.exception("Error in stream method")
             raise
 
     async def invoke(
@@ -295,9 +281,8 @@ class OpenAIChatAgent(AgentService):
             logger.info(f"Invoke completed: {len(new_chats)} new messages")
             return {"content": content, "new_chats": new_chats}
 
-        except Exception as e:
-            logger.error(f"Error in invoke method: {e}")
-            traceback.print_exc()
+        except Exception:
+            logger.exception("Error in invoke method")
             raise
 
     @staticmethod
@@ -379,8 +364,8 @@ class OpenAIChatAgent(AgentService):
             yield {"type": "final_response", "data": new_chats}
             logger.info(f"Processing completed: {chunk_count} chunks")
 
-        except Exception as e:
-            logger.error(f"Error in process_message: {e}")
+        except Exception:
+            logger.exception("Error in process_message")
             if remaining := buffer.flush():
                 yield self._flush_buffer(node, remaining)
             yield {"type": "error", "error": "메시지 처리 중 오류가 발생했습니다."}

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -67,6 +67,7 @@ class OpenAIChatAgent(AgentService):
         self.model_name = model_name
         self.tool_config = tool_config
         self.agent = None
+        self._mcp_client: MultiServerMCPClient | None = None
         self._mcp_tools: list = []
         self._personas: dict[str, str] = {}
         super().__init__(**kwargs)
@@ -88,11 +89,19 @@ class OpenAIChatAgent(AgentService):
         self._personas = _load_personas()
         logger.info(f"Loaded {len(self._personas)} personas: {list(self._personas)}")
 
-        # 2. Fetch MCP tools once
+        # 2. Start persistent MCP client (keeps stdio subprocesses alive)
         if self.mcp_config:
-            async with MultiServerMCPClient(self.mcp_config) as client:
-                self._mcp_tools = await client.get_tools()
-            logger.info(f"Cached {len(self._mcp_tools)} MCP tools")
+            try:
+                self._mcp_client = MultiServerMCPClient(self.mcp_config)
+                await self._mcp_client.__aenter__()
+                self._mcp_tools = self._mcp_client.get_tools()
+                logger.info(f"MCP client started with {len(self._mcp_tools)} tools")
+            except Exception as e:
+                logger.error(
+                    f"Failed to start MCP client, continuing without MCP tools: {e}"
+                )
+                self._mcp_client = None
+                self._mcp_tools = []
 
         # 3. Create single agent instance
         from langchain.agents.middleware import after_model, before_model
@@ -155,6 +164,17 @@ class OpenAIChatAgent(AgentService):
             ],
         )
         logger.info("Agent created successfully")
+
+    async def cleanup_async(self) -> None:
+        """Shut down the persistent MCP client if one is running."""
+        if self._mcp_client is not None:
+            try:
+                await self._mcp_client.__aexit__(None, None, None)
+                logger.info("MCP client closed")
+            except Exception as e:
+                logger.error(f"Error closing MCP client: {e}")
+            finally:
+                self._mcp_client = None
 
     async def is_healthy(self) -> tuple[bool, str]:
         """Check if the agent is healthy and ready."""

--- a/tests/services/agent_service/test_mcp_lifecycle.py
+++ b/tests/services/agent_service/test_mcp_lifecycle.py
@@ -1,0 +1,140 @@
+"""Tests for MCP client lifecycle in OpenAIChatAgent.
+
+Covers:
+- Agent initializes correctly with mcp_config=None (no MCP)
+- Agent gracefully degrades when MCP server fails to start
+- cleanup_async() is safe to call when no MCP client exists
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.services.agent_service.openai_chat_agent import OpenAIChatAgent
+
+
+def make_agent(mcp_config: dict | None = None) -> OpenAIChatAgent:
+    """Construct a minimal OpenAIChatAgent for testing."""
+    with patch("src.services.agent_service.openai_chat_agent.ChatOpenAI"):
+        agent = OpenAIChatAgent(
+            temperature=0.7,
+            top_p=0.9,
+            openai_api_key="test-key",
+            model_name="gpt-4o",
+            mcp_config=mcp_config,
+        )
+    agent.agent = MagicMock()
+    agent._personas = {}
+    return agent
+
+
+class TestMCPLifecycle:
+    async def test_initialize_async_no_mcp_config(self):
+        """Agent initializes correctly when mcp_config is None."""
+        agent = make_agent(mcp_config=None)
+
+        with (
+            patch(
+                "src.services.agent_service.openai_chat_agent._load_personas",
+                return_value={},
+            ),
+            patch(
+                "src.services.service_manager.get_mongo_client",
+                return_value=None,
+            ),
+            patch(
+                "src.services.service_manager.get_user_profile_service",
+                return_value=None,
+            ),
+            patch(
+                "src.services.agent_service.tools.registry.ToolRegistry"
+            ) as mock_registry,
+            patch(
+                "src.services.agent_service.openai_chat_agent.create_agent"
+            ) as mock_create_agent,
+        ):
+            mock_registry.return_value.get_enabled_tools.return_value = []
+            mock_create_agent.return_value = MagicMock()
+
+            await agent.initialize_async()
+
+        assert agent._mcp_client is None
+        assert agent._mcp_tools == []
+
+    async def test_initialize_async_mcp_server_failure_graceful_degradation(self):
+        """Agent continues without MCP tools when MCP server fails to start."""
+        agent = make_agent(
+            mcp_config={"bad-server": {"command": "nonexistent", "transport": "stdio"}}
+        )
+
+        with (
+            patch(
+                "src.services.agent_service.openai_chat_agent._load_personas",
+                return_value={},
+            ),
+            patch(
+                "src.services.agent_service.openai_chat_agent.MultiServerMCPClient"
+            ) as mock_mcp_cls,
+            patch(
+                "src.services.service_manager.get_mongo_client",
+                return_value=None,
+            ),
+            patch(
+                "src.services.service_manager.get_user_profile_service",
+                return_value=None,
+            ),
+            patch(
+                "src.services.agent_service.tools.registry.ToolRegistry"
+            ) as mock_registry,
+            patch(
+                "src.services.agent_service.openai_chat_agent.create_agent"
+            ) as mock_create_agent,
+        ):
+            mock_mcp_instance = MagicMock()
+            mock_mcp_instance.__aenter__ = AsyncMock(
+                side_effect=RuntimeError("Server failed to start")
+            )
+            mock_mcp_cls.return_value = mock_mcp_instance
+            mock_registry.return_value.get_enabled_tools.return_value = []
+            mock_create_agent.return_value = MagicMock()
+
+            await agent.initialize_async()
+
+        # Graceful degradation: no client, no tools, agent still created
+        assert agent._mcp_client is None
+        assert agent._mcp_tools == []
+        assert agent.agent is not None
+
+    async def test_cleanup_async_no_mcp_client_is_safe(self):
+        """cleanup_async() must not raise when no MCP client exists."""
+        agent = make_agent(mcp_config=None)
+        assert agent._mcp_client is None
+
+        # Must not raise
+        await agent.cleanup_async()
+
+        assert agent._mcp_client is None
+
+    async def test_cleanup_async_closes_running_client(self):
+        """cleanup_async() calls __aexit__ and clears the client reference."""
+        agent = make_agent(mcp_config=None)
+
+        mock_client = MagicMock()
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        agent._mcp_client = mock_client
+
+        await agent.cleanup_async()
+
+        mock_client.__aexit__.assert_awaited_once_with(None, None, None)
+        assert agent._mcp_client is None
+
+    async def test_cleanup_async_called_twice_is_safe(self):
+        """Calling cleanup_async() twice must not raise."""
+        agent = make_agent(mcp_config=None)
+
+        mock_client = MagicMock()
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        agent._mcp_client = mock_client
+
+        await agent.cleanup_async()
+        await agent.cleanup_async()  # second call: _mcp_client is None, must be safe
+
+        assert agent._mcp_client is None

--- a/tests/services/agent_service/test_mcp_lifecycle.py
+++ b/tests/services/agent_service/test_mcp_lifecycle.py
@@ -1,9 +1,9 @@
-"""Tests for MCP client lifecycle in OpenAIChatAgent.
+"""Tests for MCP tool loading in OpenAIChatAgent.
 
 Covers:
 - Agent initializes correctly with mcp_config=None (no MCP)
-- Agent gracefully degrades when MCP server fails to start
-- cleanup_async() is safe to call when no MCP client exists
+- Agent gracefully degrades when get_tools() raises
+- Agent loads tools when get_tools() succeeds
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,9 +26,9 @@ def make_agent(mcp_config: dict | None = None) -> OpenAIChatAgent:
     return agent
 
 
-class TestMCPLifecycle:
+class TestMCPToolLoading:
     async def test_initialize_async_no_mcp_config(self):
-        """Agent initializes correctly when mcp_config is None."""
+        """Agent initializes correctly when mcp_config is None — no tools loaded."""
         agent = make_agent(mcp_config=None)
 
         with (
@@ -56,11 +56,10 @@ class TestMCPLifecycle:
 
             await agent.initialize_async()
 
-        assert agent._mcp_client is None
         assert agent._mcp_tools == []
 
-    async def test_initialize_async_mcp_server_failure_graceful_degradation(self):
-        """Agent continues without MCP tools when MCP server fails to start."""
+    async def test_initialize_async_get_tools_raises_graceful_degradation(self):
+        """Agent continues without MCP tools when get_tools() raises."""
         agent = make_agent(
             mcp_config={"bad-server": {"command": "nonexistent", "transport": "stdio"}}
         )
@@ -89,7 +88,7 @@ class TestMCPLifecycle:
             ) as mock_create_agent,
         ):
             mock_mcp_instance = MagicMock()
-            mock_mcp_instance.__aenter__ = AsyncMock(
+            mock_mcp_instance.get_tools = AsyncMock(
                 side_effect=RuntimeError("Server failed to start")
             )
             mock_mcp_cls.return_value = mock_mcp_instance
@@ -98,43 +97,48 @@ class TestMCPLifecycle:
 
             await agent.initialize_async()
 
-        # Graceful degradation: no client, no tools, agent still created
-        assert agent._mcp_client is None
+        # Graceful degradation: no tools, agent still created
         assert agent._mcp_tools == []
         assert agent.agent is not None
 
-    async def test_cleanup_async_no_mcp_client_is_safe(self):
-        """cleanup_async() must not raise when no MCP client exists."""
-        agent = make_agent(mcp_config=None)
-        assert agent._mcp_client is None
+    async def test_initialize_async_get_tools_succeeds(self):
+        """Agent loads tools when get_tools() returns successfully."""
+        agent = make_agent(
+            mcp_config={"my-server": {"command": "some-cmd", "transport": "stdio"}}
+        )
+        fake_tool = MagicMock()
+        fake_tool.name = "fake_tool"
 
-        # Must not raise
-        await agent.cleanup_async()
+        with (
+            patch(
+                "src.services.agent_service.openai_chat_agent._load_personas",
+                return_value={},
+            ),
+            patch(
+                "src.services.agent_service.openai_chat_agent.MultiServerMCPClient"
+            ) as mock_mcp_cls,
+            patch(
+                "src.services.service_manager.get_mongo_client",
+                return_value=None,
+            ),
+            patch(
+                "src.services.service_manager.get_user_profile_service",
+                return_value=None,
+            ),
+            patch(
+                "src.services.agent_service.tools.registry.ToolRegistry"
+            ) as mock_registry,
+            patch(
+                "src.services.agent_service.openai_chat_agent.create_agent"
+            ) as mock_create_agent,
+        ):
+            mock_mcp_instance = MagicMock()
+            mock_mcp_instance.get_tools = AsyncMock(return_value=[fake_tool])
+            mock_mcp_cls.return_value = mock_mcp_instance
+            mock_registry.return_value.get_enabled_tools.return_value = []
+            mock_create_agent.return_value = MagicMock()
 
-        assert agent._mcp_client is None
+            await agent.initialize_async()
 
-    async def test_cleanup_async_closes_running_client(self):
-        """cleanup_async() calls __aexit__ and clears the client reference."""
-        agent = make_agent(mcp_config=None)
-
-        mock_client = MagicMock()
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        agent._mcp_client = mock_client
-
-        await agent.cleanup_async()
-
-        mock_client.__aexit__.assert_awaited_once_with(None, None, None)
-        assert agent._mcp_client is None
-
-    async def test_cleanup_async_called_twice_is_safe(self):
-        """Calling cleanup_async() twice must not raise."""
-        agent = make_agent(mcp_config=None)
-
-        mock_client = MagicMock()
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        agent._mcp_client = mock_client
-
-        await agent.cleanup_async()
-        await agent.cleanup_async()  # second call: _mcp_client is None, must be safe
-
-        assert agent._mcp_client is None
+        assert agent._mcp_tools == [fake_tool]
+        assert agent.agent is not None

--- a/yaml_files/services/agent_service/openai_chat_agent.yml
+++ b/yaml_files/services/agent_service/openai_chat_agent.yml
@@ -12,12 +12,17 @@ llm_config:
     support_image: True  # Enable image support
     # openai_api_key is loaded from LLM_API_KEY environment variable
 
+# MCP Server Configuration
+# Uncomment to enable MCP tool servers
 # mcp_config:
-#   "sequential-thinking": {
-#       "command": "npx",
-#       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
-#       "transport": "stdio",
-#   }
+#   "sequential-thinking":
+#     command: "npx"
+#     args: ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+#     transport: "stdio"
+#   "code-sandbox":
+#     command: "docker"
+#     args: ["run", "--rm", "-i", "--net=none", "--memory=512m", "--cpus=1", "ghcr.io/pydantic/mcp-run-python"]
+#     transport: "stdio"
 
 # Note: configurations of memory and vocabulary manager should be set in .env files
 


### PR DESCRIPTION
## Summary
- Fix MCP tool loading for `langchain-mcp-adapters 0.2.2` (stateless API, no context manager)
- Replace `__aenter__/__aexit__` lifecycle with direct `await client.get_tools()`
- Graceful degradation: MCP failure logs exception, agent continues without MCP tools
- Add commented code-sandbox MCP config example (Docker isolation)

**Depends on:** #feat/phase6a-builtin-tools (base branch)

## Files
- `src/services/agent_service/openai_chat_agent.py` — Stateless MCP pattern
- `src/main.py` — Cleanup in shutdown (no-op)
- `yaml_files/services/agent_service/openai_chat_agent.yml` — Code-sandbox example
- `tests/services/agent_service/test_mcp_lifecycle.py` — 3 lifecycle tests

## Test plan
- [x] 565 unit tests pass
- [x] MCP graceful degradation verified (get_tools() failure → empty tools, no crash)
- [x] Lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)