### PR TITLE
refactor: resolve known issues KI-10, KI-12, KI-13, KI-15

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -213,7 +213,7 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
             from src.services import get_agent_service
 
             agent_svc = get_agent_service()
-            if agent_svc is not None and hasattr(agent_svc, "cleanup_async"):
+            if agent_svc is not None:
                 await agent_svc.cleanup_async()
         except Exception:
             logger.exception("Error cleaning up agent MCP client")

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.core.error_classifier import ErrorSeverity
+
 
 class ModuleStatus(BaseModel):
     """Status of an individual module."""
@@ -11,7 +13,7 @@ class ModuleStatus(BaseModel):
     name: str = Field(..., description="Module name (TTS, or Agent)")
     ready: bool = Field(..., description="Whether the module is ready")
     error: str | None = Field(None, description="Error message if module is not ready")
-    severity: str | None = Field(
+    severity: ErrorSeverity | None = Field(
         None,
         description="Error severity when not ready: transient | recoverable | fatal",
     )

--- a/src/services/agent_service/service.py
+++ b/src/services/agent_service/service.py
@@ -24,6 +24,10 @@ class AgentService(ABC):
         """Async initialization: MCP tool fetch + agent creation. Default: no-op."""
         pass
 
+    async def cleanup_async(self) -> None:
+        """Async cleanup hook. Default: no-op."""
+        pass
+
     @abstractmethod
     async def is_healthy(self) -> tuple[bool, str]:
         """Check if the Agent is healthy and ready."""

--- a/src/services/agent_service/tools/builtin/filesystem_tools.py
+++ b/src/services/agent_service/tools/builtin/filesystem_tools.py
@@ -6,7 +6,6 @@ from langchain_community.tools.file_management import (
     WriteFileTool,
 )
 from langchain_core.tools import BaseTool
-from loguru import logger
 
 
 def get_filesystem_tools(root_dir: str) -> list[BaseTool]:
@@ -18,7 +17,6 @@ def get_filesystem_tools(root_dir: str) -> list[BaseTool]:
     Returns:
         List of three BaseTool instances for file read, write, and list.
     """
-    logger.info(f"Filesystem tools enabled (root_dir={root_dir})")
     return [
         ReadFileTool(root_dir=root_dir),
         WriteFileTool(root_dir=root_dir),

--- a/src/services/agent_service/tools/builtin/search_tools.py
+++ b/src/services/agent_service/tools/builtin/search_tools.py
@@ -2,7 +2,6 @@
 
 from langchain_community.tools import DuckDuckGoSearchRun
 from langchain_core.tools import BaseTool
-from loguru import logger
 
 
 def get_search_tools() -> list[BaseTool]:
@@ -11,5 +10,4 @@ def get_search_tools() -> list[BaseTool]:
     Returns:
         List containing one DuckDuckGoSearchRun instance.
     """
-    logger.info("Web search tool (DuckDuckGo) enabled")
     return [DuckDuckGoSearchRun()]

--- a/src/services/agent_service/tools/builtin/shell_tools.py
+++ b/src/services/agent_service/tools/builtin/shell_tools.py
@@ -86,5 +86,4 @@ def get_shell_tools(allowed_commands: list[str]) -> list[BaseTool]:
     Returns:
         List containing one RestrictedShellTool.
     """
-    logger.info(f"Shell tool enabled (allowed_commands={allowed_commands})")
     return [RestrictedShellTool(allowed_commands=allowed_commands)]

--- a/src/services/agent_service/tools/registry.py
+++ b/src/services/agent_service/tools/registry.py
@@ -53,7 +53,9 @@ class ToolRegistry:
             )
 
             tools.extend(get_filesystem_tools(root_dir=builtin.filesystem.root_dir))
-            logger.info("ToolRegistry: filesystem tools added")
+            logger.info(
+                f"ToolRegistry: filesystem tools added (root_dir={builtin.filesystem.root_dir})"
+            )
 
         if builtin.shell.enabled:
             from src.services.agent_service.tools.builtin.shell_tools import (
@@ -63,7 +65,9 @@ class ToolRegistry:
             tools.extend(
                 get_shell_tools(allowed_commands=builtin.shell.allowed_commands)
             )
-            logger.info("ToolRegistry: shell tool added")
+            logger.info(
+                f"ToolRegistry: shell tool added (allowed_commands={builtin.shell.allowed_commands})"
+            )
 
         if builtin.web_search.enabled:
             from src.services.agent_service.tools.builtin.search_tools import (

--- a/src/services/health.py
+++ b/src/services/health.py
@@ -4,6 +4,31 @@ from src.core.error_classifier import ErrorSeverity
 from src.models.responses import HealthResponse, ModuleStatus
 
 
+def classify_health_severity(error: str | None) -> ErrorSeverity | None:
+    """Classify an error string into an ErrorSeverity level.
+
+    Args:
+        error: Error message string, or None if no error.
+
+    Returns:
+        ErrorSeverity level, or None if error is None.
+    """
+    if error is None:
+        return None
+    lower = error.lower()
+    if any(
+        kw in lower
+        for kw in ("timeout", "timed out", "connection reset", "broken pipe")
+    ):
+        return ErrorSeverity.TRANSIENT
+    if any(
+        kw in lower
+        for kw in ("not initialized", "invalid", "validation", "value error")
+    ):
+        return ErrorSeverity.RECOVERABLE
+    return ErrorSeverity.FATAL
+
+
 class HealthService:
     """Service for checking the health of system modules."""
 
@@ -124,46 +149,30 @@ class HealthService:
         ltm_ready, ltm_error = await self.check_ltm()
         mongodb_ready, mongodb_error = await self.check_mongodb()
 
-        def _severity(error: str | None) -> str | None:
-            if error is None:
-                return None
-            lower = error.lower()
-            if any(
-                kw in lower
-                for kw in ("timeout", "timed out", "connection reset", "broken pipe")
-            ):
-                return str(ErrorSeverity.TRANSIENT)
-            if any(
-                kw in lower
-                for kw in ("not initialized", "invalid", "validation", "value error")
-            ):
-                return str(ErrorSeverity.RECOVERABLE)
-            return str(ErrorSeverity.FATAL)
-
         modules = [
             ModuleStatus(
                 name="TTS",
                 ready=tts_ready,
                 error=tts_error,
-                severity=_severity(tts_error),
+                severity=classify_health_severity(tts_error),
             ),
             ModuleStatus(
                 name="Agent",
                 ready=agent_ready,
                 error=agent_error,
-                severity=_severity(agent_error),
+                severity=classify_health_severity(agent_error),
             ),
             ModuleStatus(
                 name="LTM",
                 ready=ltm_ready,
                 error=ltm_error,
-                severity=_severity(ltm_error),
+                severity=classify_health_severity(ltm_error),
             ),
             ModuleStatus(
                 name="MongoDB",
                 ready=mongodb_ready,
                 error=mongodb_error,
-                severity=_severity(mongodb_error),
+                severity=classify_health_severity(mongodb_error),
             ),
         ]
 

--- a/src/services/health.py
+++ b/src/services/health.py
@@ -15,6 +15,8 @@ def classify_health_severity(error: str | None) -> ErrorSeverity | None:
     """
     if error is None:
         return None
+    if not error.strip():
+        return ErrorSeverity.RECOVERABLE
     lower = error.lower()
     if any(
         kw in lower

--- a/src/services/service_manager.py
+++ b/src/services/service_manager.py
@@ -571,8 +571,6 @@ def initialize_channel_service(
     Returns:
         SlackSettings instance (enabled flag + credentials resolved).
     """
-    import os
-
     from src.services.channel_service.slack_service import SlackSettings
 
     slack_cfg = _load_service_yaml(

--- a/tests/services/agent_service/test_agent_service_base.py
+++ b/tests/services/agent_service/test_agent_service_base.py
@@ -1,0 +1,55 @@
+"""Tests for AgentService base class cleanup_async method."""
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage
+
+from src.services.agent_service.service import AgentService
+
+
+class _ConcreteAgent(AgentService):
+    """Minimal concrete subclass for testing base class behavior."""
+
+    def initialize_model(self) -> BaseChatModel:
+        from unittest.mock import MagicMock
+
+        return MagicMock(spec=BaseChatModel)
+
+    async def is_healthy(self) -> tuple[bool, str]:
+        return True, ""
+
+    async def stream(
+        self,
+        messages: list[BaseMessage],
+        session_id: str = "",
+        persona_id: str = "",
+        user_id: str = "default_user",
+        agent_id: str = "default_agent",
+        context: dict | None = None,
+        is_new_session: bool = False,
+    ):
+        return
+        yield  # make it a generator
+
+    async def invoke(
+        self,
+        messages: list[BaseMessage],
+        session_id: str = "",
+        persona_id: str = "",
+        user_id: str = "default_user",
+        agent_id: str = "default_agent",
+        context: dict | None = None,
+        is_new_session: bool = False,
+    ) -> dict:
+        return {"content": "", "new_chats": []}
+
+
+def test_base_class_has_cleanup_async() -> None:
+    assert hasattr(AgentService, "cleanup_async")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_async_no_op_on_concrete_subclass() -> None:
+    agent = _ConcreteAgent()
+    # Should complete without raising
+    await agent.cleanup_async()

--- a/tests/services/test_health_severity.py
+++ b/tests/services/test_health_severity.py
@@ -1,0 +1,20 @@
+"""Tests for classify_health_severity module-level function in health.py."""
+
+from src.core.error_classifier import ErrorSeverity
+from src.services.health import classify_health_severity
+
+
+def test_severity_none_returns_none() -> None:
+    assert classify_health_severity(None) is None
+
+
+def test_severity_connection_timeout_returns_transient() -> None:
+    assert classify_health_severity("connection timeout") == ErrorSeverity.TRANSIENT
+
+
+def test_severity_not_initialized_returns_recoverable() -> None:
+    assert classify_health_severity("not initialized") == ErrorSeverity.RECOVERABLE
+
+
+def test_severity_unknown_error_returns_fatal() -> None:
+    assert classify_health_severity("unknown error xyz") == ErrorSeverity.FATAL

--- a/tests/services/test_health_severity.py
+++ b/tests/services/test_health_severity.py
@@ -16,5 +16,13 @@ def test_severity_not_initialized_returns_recoverable() -> None:
     assert classify_health_severity("not initialized") == ErrorSeverity.RECOVERABLE
 
 
+def test_severity_empty_string_returns_recoverable() -> None:
+    assert classify_health_severity("") == ErrorSeverity.RECOVERABLE
+
+
+def test_severity_whitespace_only_returns_recoverable() -> None:
+    assert classify_health_severity("   ") == ErrorSeverity.RECOVERABLE
+
+
 def test_severity_unknown_error_returns_fatal() -> None:
     assert classify_health_severity("unknown error xyz") == ErrorSeverity.FATAL


### PR DESCRIPTION
## Summary

- **KI-10**: `ModuleStatus.severity` 타입 `str | None` → `ErrorSeverity | None` 강화, `classify_health_severity()` 모듈 레벨 함수로 추출
- **KI-13**: base `AgentService`에 `cleanup_async()` no-op 추가, `main.py`의 `hasattr` 가드 제거
- **KI-12**: tool factory 중복 로깅 제거, `ToolRegistry` 로그에 config 상세 정보 추가
- **KI-15**: `initialize_channel_service()` 내 중복 `import os` 로컬 임포트 제거

## Test plan

- [x] `make lint` — ruff + black + 23 structural tests passed
- [x] `make test` — 610 passed (pre-existing 2 failures unrelated)
- [x] KI-10 severity 단위 테스트 4건 추가 (`tests/services/test_health_severity.py`)
- [x] KI-13 cleanup_async 테스트 2건 추가 (`tests/services/agent_service/test_agent_service_base.py`)
- [ ] `make e2e` — **미검증** (YAML 설정 통합 작업 별도 진행 중, MongoDB 인증 불일치로 E2E 환경 미동작 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)