### PR TITLE
docs: archive completed items to release_notes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,92 +1,19 @@
 # TODO
 
-## CI/CD & Safety Net (2026-04-08)
+> 완료된 작업은 `docs/release_notes/`에 보관됩니다.
 
-- [x] GitHub Actions CI 워크플로우 추가 (PR 트리거: lint + pytest + coverage report) `cc:DONE`
-- [x] pre-commit 훅 정상화 — .pre-commit-config.yaml에서 ruff/black 주석 해제 `cc:DONE`
-- [x] pyproject.toml에 [tool.coverage] 섹션 추가 (source, omit, threshold) `cc:DONE`
-
-## Developer Experience (2026-04-09)
-
-- [x] Makefile 추가 (make lint, make test, make e2e, make run) `cc:DONE`
-- [x] Dockerfile + docker-compose 추가 (MongoDB + Qdrant + Neo4j + backend 원커맨드 기동) `cc:DONE`
-
-## Error Handling & Observability (2026-04-10)
-
-- [x] _shutdown() 보완 — MongoDB, Agent, TTS, WebSocket 커넥션 정리 추가 `cc:DONE`
-- [x] ErrorClassifier 패턴을 서비스 초기화/헬스체크에 확산 (현재 WebSocket만 적용) `cc:DONE`
-
-## Config 정리 (2026-04-10)
-
-- [x] channel/sweep 초기화를 `_load_service_yaml()` 공통 헬퍼로 통일 `cc:DONE`
-
-## Known Issues 정리 (2026-04-10)
-
-- [x] KI-1: irodori.yml `base_url` 하드코딩 → 환경변수 오버라이드 `cc:DONE`
-- [x] KI-4: Dockerfile non-root USER 추가 `cc:DONE`
-- [x] KI-5: docker-compose.yml에 `extra_hosts: ["host.docker.internal:host-gateway"]` 추가 `cc:DONE`
-- [x] KI-6: SlackService.cleanup() → `self._client.session.close()` 수정 `cc:DONE`
-
-## Agent Skill/Tool 확장 (2026-04-11)
-
-### 빌트인 Tool + Registry (2026-04-11)
-
-- [x] Tool Registry (`tools/registry.py`) — YAML config 기반 tool 활성화/비활성화 `cc:DONE`
-- [x] LangChain 빌트인 tool 등록 — FileSystem, Shell(화이트리스트), DuckDuckGoSearch `cc:DONE`
-- [x] `openai_chat_agent.py` initialize_async에서 registry 사용하도록 변경 `cc:DONE`
-
-### MCP 서버 연결 (2026-04-11)
+## MCP 서버 연결
 
 - [ ] MCP code-sandbox 서버 연결 — `pydantic/mcp-run-python` (Docker 격리) `cc:TODO`
-- [x] MultiServerMCPClient 라이프사이클 보강 — stateless 패턴 + cleanup_async `cc:DONE`
-
-### Tool Gating Middleware (2026-04-11)
-
-- [x] `tool_gate_middleware.py` — wrap_tool_call 패턴, Shell 화이트리스트/filesystem path 범위 체크 `cc:DONE`
-
-## 대화 품질 개선 (2026-04-11)
-
-- [x] 유저 컨텍스트 프로필 — 유저 직업/관심사/일정 등 구조화 저장, 개인화 대화 `cc:DONE`
-- [x] 대화 요약/다이제스트 — 일정 턴 후 STM 자동 압축, 컨텍스트 윈도우 절약 `cc:DONE`
-
-## Idea — 중간 에이전트 레이어 (2026-04-11 추후 필요 시 추가)
-
-> Agent 응답 시간 목표: ≤0.5초. code-sandbox 실행이 이 제약을 넘는 태스크가 반복되면
-> claude code/opencode 같은 코딩 에이전트를 MCP로 연결하여 비동기 위임하는 중간 레이어 검토.
-> NanoClaw delegation과 역할 경계 정리 필요 (NanoClaw = 무거운 장기 작업, 중간 에이전트 = 수 초~수십 초 자율 추론).
-
-## Known Issues 정리 (2026-04-13)
-
-### Medium Priority
-
-- [x] KI-11: Docker 샌드박스로 충분 — Won't fix `cc:DONE`
-- [x] KI-13: `cleanup_async()` base `AgentService`에 default no-op 추가, `main.py` `hasattr` 가드 제거 `cc:DONE` (#28)
-
-### Low Priority (Quick-win batch)
-
-- [x] KI-10: `ModuleStatus.severity` 타입 `str | None` → `ErrorSeverity | None` 교체 `cc:DONE` (#28)
-- [x] KI-12: ToolRegistry/tool factory 중복 로깅 정리 — registry 레벨에서만 로깅 `cc:DONE` (#28)
-- [x] KI-14: MCP config `npx -y @modelcontextprotocol/server-sequential-thinking` -> 삭제할거임, 따라서 필요없음`cc:DONE`
-- [x] KI-15: `initialize_channel_service()` 내 `import os` 로컬 임포트 중복 제거 `cc:DONE` (#28)
-
-## YAML 설정 통합 (2026-04-13)
-
-- [x] `yaml_files/services/` 하위 파편화된 YAML을 `services.yml` / `services.docker.yml` / `services.e2e.yml`로 통합 `cc:DONE` (#29)
-- [x] YAML 로더 코드(`src/configs/`) 통합 구조에 맞게 수정 `cc:DONE` (#29)
-- [x] `main.yml` / `docker.yml` 참조 경로 업데이트 `cc:DONE` (#29)
-- [x] `e2e.sh`에서 `YAML_FILE=yaml_files/services.e2e.yml` 자동 설정 `cc:DONE` (#29)
-- [x] Docker mongo 인증 불일치 해소 — e2e용 connection_string에 인증 없는 `localhost:27017` 사용 `cc:DONE` (#29)
-
-## pending_tasks 분리 (2026-04-14)
-
-- [x] KI-17: `pending_tasks`를 LangGraph state에서 MongoDB 컬렉션으로 분리 `cc:DONE` (#30)
-- [x] `PendingTaskRepository` 패턴(SessionRegistry와 동일) 추가 `cc:DONE` (#30)
-- [x] callback 엔드포인트 경로 변경: `/nanoclaw/{session_id}` → `/nanoclaw/{task_id}` `cc:DONE` (#30)
-- [x] `task_status_middleware` 추가 — 시스템 프롬프트에 task 상태 주입 `cc:DONE` (#30)
-- [x] sweep 서비스 단순화: find_expirable 단일 쿼리로 O(N×M) 루프 제거 `cc:DONE` (#30)
 
 ## 스케줄/리마인더 (검토 필요)
 
 - [ ] 스케줄/리마인더 시스템 — cron 기반 예약 메시지 ("3시에 알려줘") `cc:TODO`
 - [ ] 감정 상태 트래킹 — 대화 감정 분석 → 캐릭터 반응 조절 `cc:TODO`
 - [ ] 데스크톱 통합 트리거 — backend는 트리거/데이터 제공, 실제 OS 연동은 DH MOD 담당 `cc:TODO`
+
+## Idea — 중간 에이전트 레이어 (추후 필요 시 추가)
+
+> Agent 응답 시간 목표: ≤0.5초. code-sandbox 실행이 이 제약을 넘는 태스크가 반복되면
+> claude code/opencode 같은 코딩 에이전트를 MCP로 연결하여 비동기 위임하는 중간 레이어 검토.
+> NanoClaw delegation과 역할 경계 정리 필요 (NanoClaw = 무거운 장기 작업, 중간 에이전트 = 수 초~수십 초 자율 추론).

--- a/docs/known_issues/KNOWN_ISSUES.md
+++ b/docs/known_issues/KNOWN_ISSUES.md
@@ -4,73 +4,36 @@
 
 형식: `- [ ] **KI-{N}** [{severity}] {component}: {one-line summary} → [상세](link)`
 
+> 해결된 이슈는 `docs/release_notes/`에 보관됩니다.
+
 ---
 
-## Backend (`backend/`)
+## Open Issues
 
-- [x] **KI-1** [Medium] config: `IRODORI_TTS_BASE_URL` 환경변수 오버라이드 추가 — `tts_config.type == 'irodori'`일 때만 적용 (#21)
-- [x] **KI-2** [Low] architecture: 6개 서비스 파일이 200줄 초과 — YAGNI. 현재 동작에 문제 없고 억지 분리 시 오히려 가독성 저하. 추후 기능 추가/변경 시 자연스럽게 분리 검토. Won't fix.
-- [X] **KI-3** [Low] security: `handlers.py:52` validate_token()이 항상 `"valid_token"` 반환 — 개인 시스템이므로 YAGNI. 멀티유저 전환 시 실제 인증 로직 필요. 현재는 하드코딩된 토큰으로 간단히 보호하는 형태 유지. Won't fix.
-
-## PR #19 (`feat/devex`) — DevEx
-
-- [x] **KI-4** [Medium] docker: Dockerfile에 non-root `appuser` 추가 및 `/app` 소유권 설정 (#21)
-- [x] **KI-5** [Medium] docker: `docker-compose.yml` backend 서비스에 `extra_hosts: ["host.docker.internal:host-gateway"]` 추가 — 이미 반영됨
-
-## PR #19 (`feat/devex`) — DevEx (추가)
-
-- [x] **KI-8** [Low] docker: `mongo:7` floating major tag — `mongo:7.0`으로 고정 완료.
-- [x] **KI-9** [Low] docker: `mem0.docker.yml`의 `neo4j graph_store` — `bolt://neo4j:7687` (compose 서비스명)으로 수정 완료, env override 주석 추가됨.
-
-## PR #20 (`feat/error-handling`) — Error Handling
-
-- [x] **KI-6** [Medium] channel: `SlackService.cleanup()` → `getattr + not session.closed` 패턴으로 교체 완료 (#21)
-- [x] **KI-7** [Low] health: `_severity()` 함수가 에러 문자열 키워드 매칭으로 severity 분류 — YAGNI. 현재 정상 동작하며 확장 예정 없음. 추후 문제 발생 시 exception 타입 기반으로 전환. Won't fix.
-- [x] **KI-10** [Low] health: `ModuleStatus.severity` 타입이 `str | None` — `ErrorSeverity | None`으로 교체하여 타입 안전성 향상 (#28)
-
-## PR #25 (`feat/phase6a-builtin-tools`) — Builtin Tools
-
-- [x] **KI-11** [Medium] shell: `RestrictedShellTool`에 `cwd` 제한 없음 — Docker 컨테이너 자체가 샌드박스이므로 컨테이너 내 `cwd` 제한은 과잉 방어. 화이트리스트 + `shell=False` + 메타문자 차단으로 충분. Won't fix.
-- [x] **KI-12** [Low] logging: `ToolRegistry`와 개별 tool factory (`get_filesystem_tools` 등)에서 중복 로깅 발생 — registry 레벨에서만 로깅하도록 정리 (#28)
-
-## PR #26 (`feat/phase6b-mcp-sandbox`) — MCP Lifecycle
-
-- [x] **KI-13** [Medium] agent: `cleanup_async()`가 `OpenAIChatAgent`에만 정의 — base `AgentService` 클래스에 default no-op 추가하고 `main.py`의 `hasattr` 가드 제거 (#28)
-- [X] **KI-14** [Low] yaml: MCP config 예시의 `npx -y @modelcontextprotocol/server-sequential-thinking` 버전 미고정 — 마이너 버전 핀 권장. -> 예시일뿐, 실제로는 안쓸거임. 삭제
-
-## PR #24 (`refactor/phase4-config-unify`) — Config Unify
-
-- [x] **KI-15** [Low] imports: `initialize_channel_service()` 내 `import os` 로컬 임포트가 모듈 레벨 임포트와 중복 — 로컬 임포트 제거 (#28)
-
-## PR #25–#27 (`feat/phase6*`) — Builtin Tools / MCP / ToolGate
+### PR #25–#27 (`feat/phase6*`) — Builtin Tools / MCP / ToolGate
 
 - [ ] **KI-16** [Low] docker: `openai_chat_agent.yml`이 Docker/로컬 공유 — `tool_config.builtin.filesystem.root_dir: /tmp/agent-workspace`가 Docker에서 ephemeral (컨테이너 재시작 시 소멸). 현재 `enabled: false`라 미발현. **해결 방향: filesystem tool 활성화 PR에서 `openai_chat_agent.docker.yml` 분리 + `docker.yml` 참조 변경 + `docker-compose.yml`에 named volume 추가 + `src/configs/agent/openai_chat_agent.py:27` Pydantic 기본값 수정.** (방법 B env var interpolation은 YAML 로더 cross-cutting 변경 필요로 reject)
 
-## PR #28 (`refactor/ki-batch-fix`) — Review Findings
+### PR #28 (`refactor/ki-batch-fix`) — Review Findings
 
 - [ ] **KI-19** [Low] test: `test_agent_service_base.py`의 `_ConcreteAgent.stream` 메서드가 `AgentService.stream` 추상 메서드와 타입 시그니처 불일치 — 테스트에서 `yield`로 async generator를 반환하지만 실제 구현체는 코루틴/제너레이터 혼합 패턴. 타입 체커(basedpyright)에서 `reportIncompatibleMethodOverride` 경고. **해결 방향: 테스트 클래스의 `stream` 메서드를 실제 구현체와 동일한 패턴으로 수정하거나, `@abstractmethod`가 아닌 concrete no-op으로 변경 검토.**
 - [ ] **KI-20** [Low] test: `/health` 엔드포인트의 `ModuleStatus.severity` 직렬화 검증 부재 — `ErrorSeverity` StrEnum이 JSON 응답에서 문자열로 직렬화되는지 API 레벨 테스트 없음. 현재는 단위 테스트만 존재. **해결 방향: `test_health.py` 또는 `test_real_e2e.py`에 `severity` 필드가 `"transient" | "recoverable" | "fatal"` 중 하나인지 검증하는 assertion 추가.**
 
-## PR #29 (`refactor/yaml-config-unify`) — Review Findings
+### PR #29 (`refactor/yaml-config-unify`) — Review Findings
 
 - [ ] **KI-21** [Low] scripts: `scripts/run.sh`가 삭제된 YAML 경로 참조 — `yaml_files/services/checkpointer.yml`, `yaml_files/services/ltm_service/mem0.yml` 등 삭제된 경로를 `_read_mongo_uri()`, `_read_qdrant_url()`에서 참조. PR #29에서 수정되지 않아 preflight check가 묵시적으로 skip됨. **해결 방향: `run.sh`의 helper 함수들이 `services.yml`을 읽도록 수정.**
-- [x] **KI-22** [Low] config: `yaml_files/services/knowledge_base.yaml` 삭제 — 통합 설정 파일에 미포함. `KnowledgeBaseService`는 코드상 존재하나 설정 로드 경로 없음. 현재 런타임에 영향 없음 (초기화되지 않는 서비스). **판정: 미사용 설정으로 안전 삭제, 추후 해당 서비스 활성화 시 `services.yml`에 추가.**
 
-## `refactor/yaml-config-unify` — Callback / STM
+### PR #30 (`refactor/ki17-pending-tasks-mongodb`) — Callback / STM
 
-- [x] **KI-17** [Medium] architecture: `pending_tasks`가 LangGraph checkpointer state에 종속 — **PR #30에서 해결**: `pending_tasks`를 별도 MongoDB 컬렉션(`pending_tasks`)으로 분리. `PendingTaskRepository` 패턴(SessionRegistry와 동일)으로 callback/delegate/sweep이 직접 읽기/쓰기. LangGraph state에서 `pending_tasks` 필드 제거.
 - [ ] **KI-18** [Low] test: E2E 테스트 실행 시 MongoDB에 테스트 세션이 누적됨 — `e2e-test-user` / `e2e-test-agent` prefix 세션이 LangGraph checkpointer 및 session_registry에 잔류. 누적된 세션은 `task_sweep_service`가 불필요한 aupdate_state를 시도해 ERROR 로그를 발생시킴. **해결 방향: E2E 테스트 teardown(fixture `yield` 이후 또는 conftest `autouse` session-scoped fixture)에서 생성된 세션을 `DELETE /v1/stm/sessions/{sid}`로 삭제.**
 
 ---
 
-## PatchNote
+## Won't Fix
 
-**2026-04-14**: PR #30 머지 — KI-17 해결
-- `pending_tasks`를 LangGraph state에서 MongoDB 컬렉션으로 분리
-- `PendingTaskRepository` 추가, `task_status_middleware` 추가
-- callback 엔드포인트 경로 변경: `/nanoclaw/{session_id}` → `/nanoclaw/{task_id}`
-- sweep 서비스 단순화: find_expirable 단일 쿼리로 O(N×M) 루프 제거
-
-**2026-04-13**: PR #28, #29 리뷰 완료 및 KNOWN_ISSUES 업데이트
-- KI-10, KI-12, KI-13, KI-15 완료 표시 (#28에서 해결)
-- KI-19 ~ KI-22 신규 추가 (리뷰 발견 이슈)
+| Issue | Reason |
+|-------|--------|
+| KI-2 | 6개 서비스 파일 200줄 초과 — YAGNI, 억지 분리 시 가독성 저하 |
+| KI-3 | `validate_token()` 항상 `"valid_token"` — 개인 시스템이므로 YAGNI |
+| KI-7 | `_severity()` 문자열 키워드 매칭 — 현재 정상 동작 |
+| KI-11 | `RestrictedShellTool` cwd 제한 없음 — Docker 샌드박스로 충분 |

--- a/docs/release_notes/v2.4.x-backlog.md
+++ b/docs/release_notes/v2.4.x-backlog.md
@@ -1,0 +1,86 @@
+# Release Notes — Pre-v2.5.0 Work (2026-04-08 ~ 2026-04-13)
+
+## CI/CD & Safety Net (2026-04-08)
+
+| Item | Status |
+|------|--------|
+| GitHub Actions CI workflow | ✅ PR triggers: lint + pytest + coverage report |
+| pre-commit hooks | ✅ ruff/black enabled |
+| pyproject.toml coverage | ✅ source, omit, threshold configured |
+
+## Developer Experience (2026-04-09)
+
+| Item | Status |
+|------|--------|
+| Makefile | ✅ lint, test, e2e, run targets |
+| Dockerfile + docker-compose | ✅ One-command startup: MongoDB + Qdrant + Neo4j + backend |
+
+## Error Handling & Observability (2026-04-10)
+
+| Item | Status |
+|------|--------|
+| `_shutdown()` | ✅ MongoDB, Agent, TTS, WebSocket connection cleanup |
+| ErrorClassifier | ✅ Pattern extended to service init/health checks |
+
+## Config Unification (2026-04-10)
+
+| Item | Status |
+|------|--------|
+| `_load_service_yaml()` | ✅ Unified helper for channel/sweep YAML loading |
+
+## Known Issues Resolved (2026-04-10)
+
+| Issue | Resolution |
+|-------|------------|
+| KI-1 | `IRODORI_TTS_BASE_URL` env var override |
+| KI-4 | Dockerfile non-root `appuser` |
+| KI-5 | `extra_hosts: ["host.docker.internal:host-gateway"]` |
+| KI-6 | `SlackService.cleanup()` safe teardown |
+
+## Agent Skill/Tool Expansion (2026-04-11)
+
+### Builtin Tools + Registry
+
+| Item | Status |
+|------|--------|
+| Tool Registry | ✅ YAML config-based activation |
+| LangChain tools | ✅ FileSystem, Shell (whitelist), DuckDuckGoSearch |
+| Agent integration | ✅ `openai_chat_agent.py` uses registry |
+
+### MCP Server
+
+| Item | Status |
+|------|--------|
+| MultiServerMCPClient | ✅ Stateless pattern + cleanup_async |
+
+### Tool Gating
+
+| Item | Status |
+|------|--------|
+| `tool_gate_middleware.py` | ✅ Shell whitelist + filesystem path validation |
+
+## Conversation Quality (2026-04-11)
+
+| Item | Status |
+|------|--------|
+| User Profile | ✅ Structured context (job, interests, schedule) |
+| Conversation Summary | ✅ Auto-compression after turn threshold |
+
+## Known Issues Resolved (2026-04-13)
+
+| Issue | Resolution |
+|-------|------------|
+| KI-11 | Won't fix — Docker sandbox sufficient |
+| KI-14 | Deleted — example config not used |
+
+---
+
+## Known Issues Remaining (Open)
+
+| Issue | Severity | Summary |
+|-------|----------|---------|
+| KI-16 | Low | Docker filesystem tool ephemeral storage |
+| KI-18 | Low | E2E test sessions accumulate in MongoDB |
+| KI-19 | Low | Test `stream` method type signature mismatch |
+| KI-20 | Low | Health endpoint `severity` serialization test missing |
+| KI-21 | Low | `run.sh` references deleted YAML paths |

--- a/docs/release_notes/v2.5.0.md
+++ b/docs/release_notes/v2.5.0.md
@@ -1,0 +1,63 @@
+# Release Notes — v2.5.0 (2026-04-14)
+
+## PR #30: Decouple pending_tasks from LangGraph to MongoDB
+
+### Summary
+
+Migrated `pending_tasks` storage from LangGraph checkpointer state to a dedicated MongoDB collection. This eliminates coupling between bookkeeping data and model inference state.
+
+### Changes
+
+| Category | Details |
+|----------|---------|
+| **Architecture** | `pending_tasks` now stored in `pending_tasks` MongoDB collection with 7-day TTL index |
+| **API** | Callback path changed: `/v1/callback/nanoclaw/{session_id}` → `/v1/callback/nanoclaw/{task_id}` |
+| **Type Safety** | `status` field uses `Literal["running", "done", "failed"]` |
+| **Timestamps** | Added `completed_at` field, set on terminal status transition |
+| **Middleware** | New `task_status_inject_hook` injects task status into system prompt |
+| **Sweep** | Simplified from O(N sessions × M tasks) to single `find_expirable` query |
+| **Tests** | E2E test orchestration with `scripts/test_dbs/` helpers, dedicated test ports |
+
+### Known Issues Resolved
+
+- **KI-17**: `pending_tasks` LangGraph state coupling → fixed
+
+### Breaking Changes
+
+- Callback endpoint path changed from `/nanoclaw/{session_id}` to `/nanoclaw/{task_id}`
+- `PendingTask` TypedDict removed from `state.py`
+- `pending_tasks` field removed from `CustomAgentState`
+
+---
+
+## PR #29: YAML Config Unification
+
+### Summary
+
+Unified 10+ fragmented service YAML configs into 3 environment-specific standalone files.
+
+### Changes
+
+| Category | Details |
+|----------|---------|
+| **Config Files** | `services.yml`, `services.docker.yml`, `services.e2e.yml` |
+| **Loader** | `services_file:` key replaces `services:` dict |
+| **E2E** | `e2e.sh` auto-sets `YAML_FILE=yaml_files/services.e2e.yml` |
+| **Docker** | MongoDB auth mismatch resolved — e2e uses `localhost:10003` |
+
+---
+
+## PR #28: Batch Known Issues Fix
+
+### Summary
+
+Resolved multiple accumulated known issues in a single PR.
+
+### Known Issues Resolved
+
+| Issue | Resolution |
+|-------|------------|
+| KI-10 | `ModuleStatus.severity` type: `str | None` → `ErrorSeverity | None` |
+| KI-12 | Logging dedup: registry-level logging only |
+| KI-13 | `cleanup_async()` no-op base method in `AgentService` |
+| KI-15 | Removed duplicate `import os` in `initialize_channel_service()` |


### PR DESCRIPTION
## Summary

- Create `docs/release_notes/` with completed work history
- Clean up `TODO.md` — keep only pending items
- Clean up `docs/known_issues/KNOWN_ISSUES.md` — keep only open issues

## Files

- `docs/release_notes/v2.5.0.md` — PR #28, #29, #30 details
- `docs/release_notes/v2.4.x-backlog.md` — Pre-v2.5.0 work summary
- `TODO.md` — Reduced from 92 to 16 lines
- `docs/known_issues/KNOWN_ISSUES.md` — Open issues only, Won't Fix section added