### PR TITLE
feat: Human-in-the-Loop approval gate for dangerous tool calls

### DIFF
--- a/docs/known_issues/KNOWN_ISSUES.md
+++ b/docs/known_issues/KNOWN_ISSUES.md
@@ -16,6 +16,12 @@
 
 ---
 
+### `feat/human_in_the_loop` — HitL Gate
+
+- [ ] **KI-22** [Low] test: `tests/e2e/test_hitl_e2e.py::TestHitLExistingFlowUnchanged::test_safe_tool_no_hitl_request` E2E 테스트가 비결정적 — LLM이 의도한 빌트인 `search_memory` 대신 위험 MCP 툴을 선택할 경우 `pytest.skip()`으로 처리됨. 안전 툴의 HitL 게이트 우회를 E2E 수준에서 신뢰성 있게 검증하지 못함. **단위 테스트 커버리지 충분**: `test_hitl_middleware.py::test_safe_tool_passes_through`, `test_builtin_tool_is_safe`가 결정론적으로 동일 로직을 검증함. **해결 방향: skip 패턴을 LLM 비결정성의 내재적 한계로 수용하거나, MCP 툴 없이 에이전트를 초기화하는 전용 E2E 픽스처를 추가해 safe-tool-only 경로를 강제함.**
+
+---
+
 ## Resolved Issues
 
 | Issue | PR | Summary | Resolution |

--- a/src/models/websocket.py
+++ b/src/models/websocket.py
@@ -222,7 +222,7 @@ class HitLRequestMessage(BaseMessage):
     type: MessageType = MessageType.HITL_REQUEST
     request_id: str = Field(..., description="Unique ID linking request/response")
     tool_name: str = Field(..., description="Name of the tool requiring approval")
-    tool_args: dict[str, str] = Field(..., description="Tool call arguments")
+    tool_args: dict[str, Any] = Field(..., description="Tool call arguments")
     session_id: str = Field(..., description="Session ID for graph resume")
 
 

--- a/src/models/websocket.py
+++ b/src/models/websocket.py
@@ -18,6 +18,7 @@ class MessageType(StrEnum):
     PONG = "pong"
     CHAT_MESSAGE = "chat_message"
     INTERRUPT_STREAM = "interrupt_stream"
+    HITL_RESPONSE = "hitl_response"
 
     # Server -> Client
     AUTHORIZE_SUCCESS = "authorize_success"
@@ -32,6 +33,7 @@ class MessageType(StrEnum):
     ERROR = "error"
     AVATAR_CONFIG_FILES = "avatar_config_files"
     AVATAR_CONFIG_SWITCHED = "avatar_config_switched"
+    HITL_REQUEST = "hitl_request"
     SET_MODEL_AND_CONF = "set_model_and_conf"
 
 
@@ -139,6 +141,14 @@ class InterruptStreamMessage(BaseMessage):
     )
 
 
+class HitLResponseMessage(BaseMessage):
+    """Client message with approval decision."""
+
+    type: MessageType = MessageType.HITL_RESPONSE
+    request_id: str = Field(..., description="Must match the hitl_request request_id")
+    approved: bool = Field(..., description="True to execute, False to deny")
+
+
 # =================================================================================
 # Server -> Client Messages
 # =================================================================================
@@ -206,6 +216,16 @@ class StreamEndMessage(BaseMessage):
     content: str
 
 
+class HitLRequestMessage(BaseMessage):
+    """Server message requesting user approval for a tool call."""
+
+    type: MessageType = MessageType.HITL_REQUEST
+    request_id: str = Field(..., description="Unique ID linking request/response")
+    tool_name: str = Field(..., description="Name of the tool requiring approval")
+    tool_args: dict[str, str] = Field(..., description="Tool call arguments")
+    session_id: str = Field(..., description="Session ID for graph resume")
+
+
 # TimelineKeyframe matches desktop-homunculus POST /vrm/{entity}/speech/timeline format.
 # { "duration": float, "targets": { "expression_name": weight } }
 TimelineKeyframe = dict[str, float | dict[str, float]]
@@ -251,7 +271,13 @@ class ErrorMessage(BaseMessage):
 # =================================================================================
 
 # Union type for all possible client messages
-ClientMessage = AuthorizeMessage | PongMessage | ChatMessage | InterruptStreamMessage
+ClientMessage = (
+    AuthorizeMessage
+    | PongMessage
+    | ChatMessage
+    | InterruptStreamMessage
+    | HitLResponseMessage
+)
 
 # Union type for all possible server messages
 ServerMessage = (
@@ -263,6 +289,7 @@ ServerMessage = (
     | ToolCallMessage
     | ToolResultMessage
     | StreamEndMessage
+    | HitLRequestMessage
     | TtsChunkMessage
     | ErrorMessage
 )

--- a/src/services/agent_service/middleware/__init__.py
+++ b/src/services/agent_service/middleware/__init__.py
@@ -1,8 +1,9 @@
 from src.services.agent_service.middleware.delegate_middleware import (
     DelegateToolMiddleware,
 )
+from src.services.agent_service.middleware.hitl_middleware import HitLMiddleware
 from src.services.agent_service.middleware.tool_gate_middleware import (
     ToolGateMiddleware,
 )
 
-__all__ = ["DelegateToolMiddleware", "ToolGateMiddleware"]
+__all__ = ["DelegateToolMiddleware", "HitLMiddleware", "ToolGateMiddleware"]

--- a/src/services/agent_service/middleware/hitl_middleware.py
+++ b/src/services/agent_service/middleware/hitl_middleware.py
@@ -58,4 +58,4 @@ class HitLMiddleware(AgentMiddleware):
             return await handler(request)
 
         logger.info(f"HitL gate: '{tool_name}' denied (request_id={request_id})")
-        return f"User denied execution of '{tool_name}'. Try a different approach."
+        return f"사용자가 '{tool_name}' 도구 실행을 거부했습니다. 다른 방법을 시도해 주세요."

--- a/src/services/agent_service/middleware/hitl_middleware.py
+++ b/src/services/agent_service/middleware/hitl_middleware.py
@@ -1,0 +1,61 @@
+"""HitLMiddleware — Human-in-the-Loop approval gate for dangerous tool calls."""
+
+from uuid import uuid4
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langgraph.types import interrupt
+from loguru import logger
+
+# Hardcoded deny-list for Phase 1 MVP
+_STATIC_DENY_LIST: frozenset[str] = frozenset()
+
+# delegate_task tool name — matches DelegateTaskTool.name field
+_DELEGATE_TOOL_NAME = "delegate_task"
+
+
+class HitLMiddleware(AgentMiddleware):
+    """Intercepts dangerous tool calls and requests user approval via interrupt().
+
+    Dangerous tools: MCP tools (dynamic, from agent init) + delegate_task + static deny-list.
+    Safe tools pass through unchanged.
+    """
+
+    def __init__(self, mcp_tool_names: set[str] | None = None) -> None:
+        self._dangerous_names: frozenset[str] = frozenset(
+            (mcp_tool_names or set()) | _STATIC_DENY_LIST | {_DELEGATE_TOOL_NAME}
+        )
+
+    def is_dangerous(self, tool_name: str) -> bool:
+        """Check if a tool requires HitL approval."""
+        return tool_name in self._dangerous_names
+
+    async def awrap_tool_call(self, request, handler):
+        """Wrap tool call with interrupt() for dangerous tools."""
+        tool_name: str = request.tool_call["name"]
+
+        if not self.is_dangerous(tool_name):
+            return await handler(request)
+
+        args = request.tool_call.get("args", {})
+        request_id = str(uuid4())
+
+        logger.info(
+            f"HitL gate: requesting approval for '{tool_name}' (request_id={request_id})"
+        )
+
+        # interrupt() raises GraphInterrupt, caught by LangGraph runtime
+        # Returns the resume value from Command(resume=...) when graph is resumed
+        resume_value = interrupt(
+            {
+                "tool_name": tool_name,
+                "tool_args": args,
+                "request_id": request_id,
+            }
+        )
+
+        if resume_value.get("approved"):
+            logger.info(f"HitL gate: '{tool_name}' approved (request_id={request_id})")
+            return await handler(request)
+
+        logger.info(f"HitL gate: '{tool_name}' denied (request_id={request_id})")
+        return f"User denied execution of '{tool_name}'. Try a different approach."

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -276,6 +276,7 @@ class OpenAIChatAgent(AgentService):
         *,
         user_id: str = "",
         agent_id: str = "",
+        context: dict | None = None,
     ):
         """Resume graph after HitL approval/denial.
 
@@ -288,7 +289,10 @@ class OpenAIChatAgent(AgentService):
         config = {"configurable": {"thread_id": session_id}}
         resume_value = Command(resume={"approved": approved, "request_id": request_id})
         astream_iter = self.agent.astream(
-            resume_value, config=config, stream_mode=["messages", "updates"]
+            resume_value,
+            config=config,
+            stream_mode=["messages", "updates"],
+            context=context,
         )
         async for event in self._consume_astream(astream_iter, session_id):
             if event["type"] == "final_response":
@@ -386,7 +390,7 @@ class OpenAIChatAgent(AgentService):
         try:
             async for stream_type, data in astream_iter:
                 if stream_type == "updates":
-                    if "__interrupt__" in data:
+                    if data.get("__interrupt__"):
                         interrupt_value = data["__interrupt__"][0].value
                         yield {
                             "type": "hitl_request",

--- a/src/services/agent_service/openai_chat_agent.py
+++ b/src/services/agent_service/openai_chat_agent.py
@@ -19,6 +19,7 @@ from loguru import logger
 from src.services.agent_service.middleware.delegate_middleware import (
     DelegateToolMiddleware,
 )
+from src.services.agent_service.middleware.hitl_middleware import HitLMiddleware
 from src.services.agent_service.middleware.tool_gate_middleware import (
     ToolGateMiddleware,
 )
@@ -159,6 +160,9 @@ class OpenAIChatAgent(AgentService):
             ),
         )
 
+        mcp_tool_names = {t.name for t in self._mcp_tools}
+        hitl_gate = HitLMiddleware(mcp_tool_names=mcp_tool_names)
+
         self.agent = create_agent(
             model=self.llm,
             tools=custom_tools,
@@ -166,6 +170,7 @@ class OpenAIChatAgent(AgentService):
             checkpointer=checkpointer,
             middleware=[
                 tool_gate,
+                hitl_gate,
                 DelegateToolMiddleware(),
                 before_model(profile_retrieve_hook),
                 before_model(summary_inject_hook),
@@ -232,6 +237,7 @@ class OpenAIChatAgent(AgentService):
 
             new_chats: list[BaseMessage] = []
             had_error = False
+            had_hitl_request = False
             async for item in self._process_message(
                 messages=messages,
                 config=config,
@@ -239,14 +245,17 @@ class OpenAIChatAgent(AgentService):
                 agent_id=agent_id,
                 context=context,
             ):
-                if item["type"] != "final_response":
+                if item["type"] == "hitl_request":
+                    had_hitl_request = True
+                    yield item
+                elif item["type"] != "final_response":
                     if item["type"] == "error":
                         had_error = True
                     yield item
                 else:
                     new_chats = item["data"]
 
-            if not had_error:
+            if not had_error and not had_hitl_request:
                 content = new_chats[-1].content if new_chats else ""
                 yield {
                     "type": "stream_end",
@@ -258,6 +267,42 @@ class OpenAIChatAgent(AgentService):
         except Exception:
             logger.exception("Error in stream method")
             raise
+
+    async def resume_after_approval(
+        self,
+        session_id: str,
+        approved: bool,
+        request_id: str,
+        *,
+        user_id: str = "",
+        agent_id: str = "",
+    ):
+        """Resume graph after HitL approval/denial.
+
+        CRITICAL: Command(resume=...) is passed as the FIRST POSITIONAL argument
+        to astream, replacing the normal input dict. This is the documented
+        LangGraph resume convention.
+        """
+        from langgraph.types import Command
+
+        config = {"configurable": {"thread_id": session_id}}
+        resume_value = Command(resume={"approved": approved, "request_id": request_id})
+        astream_iter = self.agent.astream(
+            resume_value, config=config, stream_mode=["messages", "updates"]
+        )
+        async for event in self._consume_astream(astream_iter, session_id):
+            if event["type"] == "final_response":
+                new_chats = event["data"]
+                content = new_chats[-1].content if new_chats else ""
+                yield {
+                    "type": "stream_end",
+                    "turn_id": "",
+                    "session_id": session_id,
+                    "content": content,
+                    "new_chats": new_chats,
+                }
+            else:
+                yield event
 
     async def invoke(
         self,
@@ -319,6 +364,18 @@ class OpenAIChatAgent(AgentService):
     ):
         """Process messages and yield streaming events."""
         logger.debug(f"Processing {len(messages)} messages with agent")
+        astream_iter = self.agent.astream(
+            {"messages": messages, "user_id": user_id, "agent_id": agent_id},
+            config=config,
+            context=context,
+            stream_mode=["messages", "updates"],
+        )
+        session_id = config["configurable"]["thread_id"]
+        async for event in self._consume_astream(astream_iter, session_id):
+            yield event
+
+    async def _consume_astream(self, astream_iter, session_id: str):
+        """Consume agent astream iterator, yielding streaming events."""
         node = None
         tool_called = False
         gathered = ""
@@ -327,13 +384,19 @@ class OpenAIChatAgent(AgentService):
         new_chats: list[BaseMessage] = []
 
         try:
-            async for stream_type, data in self.agent.astream(
-                {"messages": messages, "user_id": user_id, "agent_id": agent_id},
-                config=config,
-                context=context,
-                stream_mode=["messages", "updates"],
-            ):
+            async for stream_type, data in astream_iter:
                 if stream_type == "updates":
+                    if "__interrupt__" in data:
+                        interrupt_value = data["__interrupt__"][0].value
+                        yield {
+                            "type": "hitl_request",
+                            "request_id": interrupt_value["request_id"],
+                            "tool_name": interrupt_value["tool_name"],
+                            "tool_args": interrupt_value["tool_args"],
+                            "session_id": session_id,
+                        }
+                        return
+
                     for node_name, updates in data.items():
                         if node_name in ("model", "tools"):
                             new_chats.extend(updates.get("messages", []))
@@ -380,10 +443,10 @@ class OpenAIChatAgent(AgentService):
                 chunk_count += 1
 
             yield {"type": "final_response", "data": new_chats}
-            logger.info(f"Processing completed: {chunk_count} chunks")
+            logger.info(f"Stream processing completed: {chunk_count} chunks")
 
         except Exception:
-            logger.exception("Error in process_message")
+            logger.warning("Error in stream processing", exc_info=True)
             if remaining := buffer.flush():
                 yield self._flush_buffer(node, remaining)
             yield {"type": "error", "error": "메시지 처리 중 오류가 발생했습니다."}

--- a/src/services/websocket_service/manager/handlers.py
+++ b/src/services/websocket_service/manager/handlers.py
@@ -22,6 +22,7 @@ from src.services.service_manager import (
     get_tts_service,
 )
 from src.services.websocket_service.message_processor import MessageProcessor
+from src.services.websocket_service.message_processor.models import TurnStatus
 
 
 class MessageHandler:
@@ -272,6 +273,71 @@ class MessageHandler:
                 connection_id,
                 ErrorMessage(error=f"Failed to process message: {e!s}"),
             )
+
+    async def handle_hitl_response(
+        self,
+        connection_id: UUID,
+        message_data: dict,
+        forward_events_fn,
+    ) -> None:
+        """Handle HitL approval/denial from client.
+
+        Args:
+            connection_id: Connection identifier.
+            message_data: Message data containing request_id and approved.
+            forward_events_fn: Function to forward events to client.
+        """
+        connection_state = self.get_connection(connection_id)
+        if not connection_state or not connection_state.message_processor:
+            await self.send_message(
+                connection_id, ErrorMessage(error="No active session", code=4004)
+            )
+            return
+
+        processor = connection_state.message_processor
+        turn_id = processor._current_turn_id
+        if not turn_id:
+            await self.send_message(
+                connection_id,
+                ErrorMessage(error="No active turn awaiting approval", code=4004),
+            )
+            return
+
+        turn = processor.turns.get(turn_id)
+        if not turn or turn.status != TurnStatus.AWAITING_APPROVAL:
+            await self.send_message(
+                connection_id,
+                ErrorMessage(error="No pending approval request", code=4004),
+            )
+            return
+
+        request_id = message_data.get("request_id", "")
+        approved = message_data.get("approved", False)
+        session_id = turn.session_id
+
+        agent_service = get_agent_service()
+        if not agent_service:
+            await self.send_message(
+                connection_id,
+                ErrorMessage(error="Agent service unavailable"),
+            )
+            return
+
+        await processor.update_turn_status(turn_id, TurnStatus.PROCESSING)
+
+        agent_stream = agent_service.resume_after_approval(
+            session_id=session_id,
+            approved=approved,
+            request_id=request_id,
+        )
+
+        await processor.attach_agent_stream(turn_id, agent_stream)
+
+        forward_task = asyncio.create_task(
+            forward_events_fn(connection_id, turn_id),
+            name=f"ws-forward-events-hitl-{turn_id}",
+        )
+        await processor.add_task_to_turn(turn_id, forward_task)
 
     async def handle_interrupt(
         self, connection_id: UUID, turn_id: str | None = None

--- a/src/services/websocket_service/manager/websocket_manager.py
+++ b/src/services/websocket_service/manager/websocket_manager.py
@@ -398,6 +398,17 @@ class WebSocketManager:
                 message = InterruptStreamMessage(**message_data)
                 await self.interrupt_active_turn(connection_id, message.turn_id)
 
+            elif message_type == MessageType.HITL_RESPONSE:
+                if not connection_state.is_authenticated:
+                    await self.send_message(
+                        connection_id,
+                        ErrorMessage(error="Authentication required"),
+                    )
+                    return
+                await self._message_handler.handle_hitl_response(
+                    connection_id, message_data, self._forward_turn_events
+                )
+
             else:
                 # Check if connection is authenticated for other message types
                 if not connection_state.is_authenticated:

--- a/src/services/websocket_service/message_processor/event_handlers.py
+++ b/src/services/websocket_service/message_processor/event_handlers.py
@@ -55,6 +55,15 @@ class EventHandler:
                     )
                     continue
 
+                if event_type == "hitl_request":
+                    await self.processor.update_turn_status(
+                        turn_id, TurnStatus.AWAITING_APPROVAL
+                    )
+                    await self.processor._put_event(turn_id, event)
+                    await self._signal_token_stream_closed(turn_id)
+                    await self._wait_for_token_queue(turn_id)
+                    return  # Exit producer; graph is suspended at checkpoint
+
                 if event_type == "stream_end":
                     # Pop new_chats before forwarding — BaseMessage objects are not
                     # JSON-serializable and must not reach the WebSocket client.

--- a/src/services/websocket_service/message_processor/models.py
+++ b/src/services/websocket_service/message_processor/models.py
@@ -24,6 +24,7 @@ class TurnStatus(Enum):
     COMPLETED = "completed"
     INTERRUPTED = "interrupted"
     FAILED = "failed"
+    AWAITING_APPROVAL = "awaiting_approval"
 
 
 @dataclass

--- a/src/services/websocket_service/message_processor/processor.py
+++ b/src/services/websocket_service/message_processor/processor.py
@@ -269,7 +269,7 @@ class MessageProcessor:
             turn.metadata.update(metadata)
 
         await self.update_turn_status(turn_id, TurnStatus.FAILED, error_message)
-        logger.error(f"Failed turn {turn_id}: {error_message}")
+        logger.warning(f"Failed turn {turn_id}: {error_message}")
         return True
 
     async def handle_interrupt(
@@ -298,6 +298,24 @@ class MessageProcessor:
             return None
 
         previous_status = turn.status
+
+        # If turn is awaiting HitL approval, send deny to clear graph checkpoint
+        if previous_status == TurnStatus.AWAITING_APPROVAL:
+            from src.services.service_manager import get_agent_service
+
+            agent_service = get_agent_service()
+            if agent_service:
+                session_id = turn.session_id
+                try:
+                    async for _ in agent_service.resume_after_approval(
+                        session_id=session_id, approved=False, request_id=""
+                    ):
+                        pass
+                except Exception:
+                    logger.warning(
+                        f"Failed to clear HitL checkpoint for turn {target_turn_id}"
+                    )
+
         await self.update_turn_status(target_turn_id, TurnStatus.INTERRUPTED, reason)
         if previous_status != TurnStatus.INTERRUPTED:
             self.total_interrupted += 1
@@ -397,6 +415,9 @@ class MessageProcessor:
         turn = self.turns.get(turn_id)
         if not turn:
             raise ValueError(f"Unknown turn: {turn_id}")
+
+        # Reset token stream state for resume path (HitL approval)
+        turn.token_stream_closed = False
 
         self._task_manager.ensure_token_consumer(turn_id)
 
@@ -510,16 +531,18 @@ class MessageProcessor:
         if queue is None:
             raise ValueError(f"Turn {turn_id} has no event queue")
 
+        event: dict[str, Any] = {}
         try:
             while True:
                 event = await queue.get()
                 queue.task_done()
                 yield event
 
-                if event.get("type") in {"stream_end", "error"}:
+                if event.get("type") in {"stream_end", "error", "hitl_request"}:
                     break
         finally:
-            await self.cleanup(turn_id)
+            if event.get("type") != "hitl_request":
+                await self.cleanup(turn_id)
 
     async def _put_event(self, turn_id: str, event: dict[str, Any]) -> None:
         """Put an event onto the turn's queue respecting backpressure."""

--- a/tests/e2e/test_hitl_e2e.py
+++ b/tests/e2e/test_hitl_e2e.py
@@ -1,0 +1,457 @@
+"""E2E tests for Human-in-the-Loop (HitL) WebSocket flow.
+
+Requires: FASTAPI_URL env var pointing to a running backend.
+    FASTAPI_URL=http://127.0.0.1:7123 uv run pytest -m e2e tests/e2e/test_hitl_e2e.py --tb=long
+
+Tests cover:
+  - hitl_response without pending approval (protocol error)
+  - Normal chat without tool calls (no hitl_request, flow unchanged)
+  - Safe built-in tool bypass (no hitl_request for non-dangerous tools)
+  - Full approve flow (chat → hitl_request → approve → stream_end)
+  - Full deny flow (chat → hitl_request → deny → stream_end)
+  - Multi-tool sequential approval
+"""
+
+import asyncio
+import json
+
+import pytest
+import websockets
+
+TOKEN = "demo-token"
+AGENT_ID = "e2e-hitl-agent"
+USER_ID = "e2e-hitl-user"
+PERSONA_ID = "yuri"
+CONNECT_TIMEOUT = 10
+RECV_TIMEOUT = 90.0
+
+# Prompt designed to trigger delegate_task tool (always in dangerous list)
+DELEGATE_PROMPT = (
+    "다음 작업을 NanoClaw에게 위임해줘: 'hello world를 출력하는 간단한 스크립트를 만들어줘'. "
+    "반드시 delegate_task 도구를 사용해서 위임해."
+)
+
+# Simple greeting that should NOT trigger any dangerous tool
+SAFE_CHAT_PROMPT = "안녕! 한 문장으로 짧게 인사해줘."
+
+# Prompt that should trigger a built-in safe tool (memory search)
+SAFE_TOOL_PROMPT = "내 기억에서 '취미'에 대해 검색해줘. search_memory 도구를 사용해."
+
+
+async def _connect_and_authorize(ws_url: str):
+    """Connect to WebSocket and complete authorization.
+
+    Returns the authorized websocket connection.
+    """
+    ws = await websockets.connect(
+        ws_url,
+        open_timeout=CONNECT_TIMEOUT,
+        ping_interval=20,
+        ping_timeout=10,
+        close_timeout=5,
+    )
+    await ws.send(json.dumps({"type": "authorize", "token": TOKEN}))
+
+    while True:
+        raw = await asyncio.wait_for(ws.recv(), timeout=RECV_TIMEOUT)
+        data = json.loads(raw)
+        if data.get("type") == "ping":
+            await ws.send(json.dumps({"type": "pong"}))
+            continue
+        if data.get("type") == "authorize_success":
+            return ws
+        if data.get("type") == "authorize_error":
+            await ws.close()
+            pytest.fail(f"WebSocket authorization failed: {data.get('error')}")
+
+
+async def _recv_skip_ping(
+    ws,
+    timeout: float = RECV_TIMEOUT,
+) -> dict:
+    """Receive next non-ping message from WebSocket."""
+    while True:
+        raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        data = json.loads(raw)
+        if data.get("type") == "ping":
+            await ws.send(json.dumps({"type": "pong"}))
+            continue
+        return data
+
+
+async def _collect_until_terminal(
+    ws,
+    terminal_types: set[str] | None = None,
+    timeout: float = RECV_TIMEOUT,
+) -> list[dict]:
+    """Collect events until a terminal event type is received.
+
+    Terminal types default to stream_end, error, and hitl_request.
+    """
+    if terminal_types is None:
+        terminal_types = {"stream_end", "error", "hitl_request"}
+
+    events: list[dict] = []
+    try:
+        while True:
+            event = await _recv_skip_ping(ws, timeout=timeout)
+            events.append(event)
+            if event.get("type") in terminal_types:
+                break
+    except TimeoutError:
+        received = [e.get("type") for e in events]
+        pytest.fail(
+            f"Timed out after {timeout}s waiting for terminal event "
+            f"{terminal_types}. Received: {received}"
+        )
+    return events
+
+
+def _send_chat(
+    content: str,
+    session_id: str | None = None,
+    tts_enabled: bool = False,
+) -> str:
+    """Build a chat_message JSON payload."""
+    return json.dumps(
+        {
+            "type": "chat_message",
+            "content": content,
+            "session_id": session_id,
+            "agent_id": AGENT_ID,
+            "user_id": USER_ID,
+            "persona_id": PERSONA_ID,
+            "tts_enabled": tts_enabled,
+        }
+    )
+
+
+@pytest.mark.e2e
+class TestHitLProtocol:
+    """Protocol-level HitL tests — always work against a real backend."""
+
+    async def test_hitl_response_without_pending_approval(self, e2e_session):
+        """Sending hitl_response when no approval is pending returns error."""
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            # Send hitl_response without any prior hitl_request
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hitl_response",
+                        "request_id": "nonexistent-request-id",
+                        "approved": True,
+                    }
+                )
+            )
+
+            # Should receive an error response
+            event = await _recv_skip_ping(ws, timeout=15.0)
+            assert event.get("type") == "error", (
+                f"Expected error for hitl_response without pending approval, "
+                f"got: {event}"
+            )
+        finally:
+            await ws.close()
+
+    async def test_hitl_response_requires_authentication(self, e2e_session):
+        """Sending hitl_response before authorization returns error."""
+        ws = await websockets.connect(
+            e2e_session["ws_url"],
+            open_timeout=CONNECT_TIMEOUT,
+            ping_interval=20,
+            ping_timeout=10,
+            close_timeout=5,
+        )
+        try:
+            # Send hitl_response without authorizing first
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hitl_response",
+                        "request_id": "req-1",
+                        "approved": True,
+                    }
+                )
+            )
+
+            event = await _recv_skip_ping(ws, timeout=15.0)
+            assert (
+                event.get("type") == "error"
+            ), f"Expected error for unauthenticated hitl_response, got: {event}"
+            assert (
+                "authentication" in event.get("error", "").lower()
+                or "auth" in event.get("error", "").lower()
+            ), f"Error should mention authentication: {event.get('error')}"
+        finally:
+            await ws.close()
+
+
+@pytest.mark.e2e
+class TestHitLExistingFlowUnchanged:
+    """Verify existing chat flows are NOT affected by HitL."""
+
+    async def test_normal_chat_no_hitl_request(self, e2e_session):
+        """Normal chat without tool calls produces no hitl_request events."""
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            await ws.send(_send_chat(SAFE_CHAT_PROMPT))
+
+            events = await _collect_until_terminal(ws)
+            event_types = [e["type"] for e in events]
+
+            assert (
+                "hitl_request" not in event_types
+            ), "Normal chat should not trigger hitl_request"
+            assert "stream_start" in event_types, "Missing stream_start event"
+            assert "stream_end" in event_types, "Missing stream_end event"
+        finally:
+            await ws.close()
+
+    async def test_normal_chat_stream_tokens_present(self, e2e_session):
+        """Normal chat produces stream_token events as before."""
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            await ws.send(_send_chat(SAFE_CHAT_PROMPT))
+
+            events = await _collect_until_terminal(ws)
+            token_events = [e for e in events if e["type"] == "stream_token"]
+
+            assert (
+                len(token_events) > 0
+            ), "Expected at least one stream_token event in normal chat"
+        finally:
+            await ws.close()
+
+    async def test_safe_tool_no_hitl_request(self, e2e_session):
+        """Built-in safe tool calls (e.g. search_memory) bypass HitL gate.
+
+        If the LLM non-deterministically chooses a dangerous tool (MCP)
+        instead of the built-in search_memory, the test is skipped.
+        """
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            await ws.send(_send_chat(SAFE_TOOL_PROMPT))
+
+            events = await _collect_until_terminal(ws)
+            event_types = [e["type"] for e in events]
+
+            if "hitl_request" in event_types:
+                pytest.skip(
+                    "Agent chose a dangerous tool instead of built-in search_memory "
+                    "(LLM non-determinism) — cannot verify safe-tool bypass. "
+                    f"Events: {event_types}"
+                )
+            # Should complete normally
+            assert (
+                "stream_end" in event_types or "error" in event_types
+            ), "Chat with safe tool should reach stream_end or error"
+        finally:
+            await ws.close()
+
+
+@pytest.mark.e2e
+class TestHitLApproveFlow:
+    """Full HitL approve flow — requires agent to call delegate_task."""
+
+    async def test_hitl_approve_completes_stream(self, e2e_session):
+        """Send chat → receive hitl_request → approve → stream_end.
+
+        This test prompts the agent to use delegate_task, which is always
+        in the HitL dangerous list. If the agent does not call delegate_task,
+        the test is skipped (LLM behavior is non-deterministic).
+        """
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            await ws.send(_send_chat(DELEGATE_PROMPT))
+
+            # Collect events until hitl_request or stream_end
+            events = await _collect_until_terminal(ws)
+            event_types = [e["type"] for e in events]
+
+            if "hitl_request" not in event_types:
+                pytest.skip(
+                    "Agent did not call a dangerous tool — cannot test approve flow. "
+                    f"Events: {event_types}"
+                )
+
+            hitl_event = next(e for e in events if e["type"] == "hitl_request")
+
+            # Validate hitl_request fields
+            assert "request_id" in hitl_event, "hitl_request missing request_id"
+            assert "tool_name" in hitl_event, "hitl_request missing tool_name"
+            assert "tool_args" in hitl_event, "hitl_request missing tool_args"
+            assert "session_id" in hitl_event, "hitl_request missing session_id"
+
+            # Send approval
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hitl_response",
+                        "request_id": hitl_event["request_id"],
+                        "approved": True,
+                    }
+                )
+            )
+
+            # Collect remaining events until stream_end
+            # After approval, may get more hitl_requests (multi-tool), or stream_end
+            remaining = await _collect_until_terminal(
+                ws,
+                terminal_types={"stream_end", "error"},
+                timeout=RECV_TIMEOUT,
+            )
+            remaining_types = [e["type"] for e in remaining]
+
+            assert (
+                "stream_end" in remaining_types or "error" in remaining_types
+            ), f"Expected stream_end or error after approval. Got: {remaining_types}"
+        finally:
+            await ws.close()
+
+    async def test_hitl_request_has_correct_schema(self, e2e_session):
+        """hitl_request event must contain all required fields with correct types."""
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            await ws.send(_send_chat(DELEGATE_PROMPT))
+
+            events = await _collect_until_terminal(ws)
+            event_types = [e["type"] for e in events]
+
+            if "hitl_request" not in event_types:
+                pytest.skip(
+                    "Agent did not call a dangerous tool — cannot validate schema. "
+                    f"Events: {event_types}"
+                )
+
+            hitl_event = next(e for e in events if e["type"] == "hitl_request")
+
+            # Validate field types
+            assert isinstance(hitl_event["request_id"], str), "request_id must be str"
+            assert isinstance(hitl_event["tool_name"], str), "tool_name must be str"
+            assert isinstance(hitl_event["tool_args"], dict), "tool_args must be dict"
+            assert isinstance(hitl_event["session_id"], str), "session_id must be str"
+            assert len(hitl_event["request_id"]) > 0, "request_id must not be empty"
+            assert len(hitl_event["tool_name"]) > 0, "tool_name must not be empty"
+        finally:
+            await ws.close()
+
+
+@pytest.mark.e2e
+class TestHitLDenyFlow:
+    """Full HitL deny flow — requires agent to call delegate_task."""
+
+    async def test_hitl_deny_completes_stream(self, e2e_session):
+        """Send chat → receive hitl_request → deny → agent handles denial → stream_end."""
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            await ws.send(_send_chat(DELEGATE_PROMPT))
+
+            events = await _collect_until_terminal(ws)
+            event_types = [e["type"] for e in events]
+
+            if "hitl_request" not in event_types:
+                pytest.skip(
+                    "Agent did not call a dangerous tool — cannot test deny flow. "
+                    f"Events: {event_types}"
+                )
+
+            hitl_event = next(e for e in events if e["type"] == "hitl_request")
+
+            # Send denial
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "hitl_response",
+                        "request_id": hitl_event["request_id"],
+                        "approved": False,
+                    }
+                )
+            )
+
+            # After denial, agent should get error message and eventually stream_end
+            remaining = await _collect_until_terminal(
+                ws,
+                terminal_types={"stream_end", "error"},
+                timeout=RECV_TIMEOUT,
+            )
+            remaining_types = [e["type"] for e in remaining]
+
+            assert (
+                "stream_end" in remaining_types or "error" in remaining_types
+            ), f"Expected stream_end or error after denial. Got: {remaining_types}"
+        finally:
+            await ws.close()
+
+
+@pytest.mark.e2e
+class TestHitLMultiToolApproval:
+    """Multi-tool sequential approval — approve first, handle second."""
+
+    async def test_hitl_multi_tool_sequential_approval(self, e2e_session):
+        """If agent calls 2+ dangerous tools, approve each sequentially."""
+        ws = await _connect_and_authorize(e2e_session["ws_url"])
+        try:
+            # Use a prompt that might trigger multiple tool calls
+            multi_prompt = (
+                "다음 두 작업을 각각 NanoClaw에게 위임해줘: "
+                "1) 'hello world 스크립트 작성' "
+                "2) '간단한 테스트 작성'. "
+                "각각 별도로 delegate_task 도구를 사용해서 위임해."
+            )
+            await ws.send(_send_chat(multi_prompt))
+
+            hitl_count = 0
+            all_events: list[dict] = []
+
+            # Collect first batch of events
+            events = await _collect_until_terminal(ws)
+            all_events.extend(events)
+            event_types = [e["type"] for e in events]
+
+            if "hitl_request" not in event_types:
+                pytest.skip(
+                    "Agent did not call a dangerous tool — cannot test multi-tool flow. "
+                    f"Events: {event_types}"
+                )
+
+            # Approve and collect, up to 5 iterations (safety limit)
+            for _ in range(5):
+                last_event = all_events[-1]
+                if last_event["type"] != "hitl_request":
+                    break
+
+                hitl_count += 1
+                # Approve the tool call
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "hitl_response",
+                            "request_id": last_event["request_id"],
+                            "approved": True,
+                        }
+                    )
+                )
+
+                # Collect next batch
+                next_events = await _collect_until_terminal(
+                    ws,
+                    terminal_types={"stream_end", "error", "hitl_request"},
+                    timeout=RECV_TIMEOUT,
+                )
+                all_events.extend(next_events)
+
+            final_types = [e["type"] for e in all_events]
+
+            # Must eventually reach stream_end or error
+            assert "stream_end" in final_types or "error" in final_types, (
+                f"Expected stream_end or error after approving all tools. "
+                f"HitL requests seen: {hitl_count}. Events: {final_types}"
+            )
+
+            # Should have seen at least 1 hitl_request (already verified by skip above)
+            assert (
+                hitl_count >= 1
+            ), f"Expected at least 1 hitl_request, got {hitl_count}"
+        finally:
+            await ws.close()

--- a/tests/spike/test_interrupt_in_middleware.py
+++ b/tests/spike/test_interrupt_in_middleware.py
@@ -1,0 +1,177 @@
+"""Spike test: verify interrupt() works inside awrap_tool_call middleware.
+
+This determines whether Option A (middleware-based HitL) is viable.
+Uses a fake chat model with bind_tools support to avoid external API dependency.
+"""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.language_models import FakeMessagesListChatModel
+from langchain_core.language_models.chat_models import LanguageModelInput
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool, tool
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command, interrupt
+
+
+class FakeToolChatModel(FakeMessagesListChatModel):
+    """FakeMessagesListChatModel that supports bind_tools (returns self)."""
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, BaseMessage]:
+        return self
+
+
+class InterruptMiddleware(AgentMiddleware):
+    """Test middleware that calls interrupt() for a specific tool."""
+
+    async def awrap_tool_call(self, request, handler):
+        tool_name = request.tool_call["name"]
+        if tool_name == "dangerous_tool":
+            resume_value = interrupt(
+                {
+                    "tool_name": tool_name,
+                    "tool_args": request.tool_call.get("args", {}),
+                    "request_id": "test-123",
+                }
+            )
+            if resume_value.get("approved"):
+                return await handler(request)
+            return "User denied execution."
+        return await handler(request)
+
+
+@tool
+def dangerous_tool(query: str) -> str:
+    """A tool that requires approval."""
+    return f"Executed with: {query}"
+
+
+def _make_fake_llm() -> FakeToolChatModel:
+    """Create a fake LLM that first calls dangerous_tool, then returns final answer."""
+    return FakeToolChatModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "dangerous_tool",
+                        "args": {"query": "hello"},
+                        "id": "call_123",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            AIMessage(content="Done! The tool returned the result."),
+        ]
+    )
+
+
+def _check_messages_for(messages: list, substring: str) -> bool:
+    """Check if any message (object or plain string) contains the substring."""
+    for msg in messages:
+        text = msg.content if hasattr(msg, "content") else str(msg)
+        if substring in text.lower():
+            return True
+    return False
+
+
+@pytest.mark.asyncio
+async def test_interrupt_in_middleware():
+    """Verify interrupt() works inside awrap_tool_call."""
+    llm = _make_fake_llm()
+    checkpointer = MemorySaver()
+
+    agent = create_agent(
+        model=llm,
+        tools=[dangerous_tool],
+        checkpointer=checkpointer,
+        middleware=[InterruptMiddleware()],
+    )
+
+    config = {"configurable": {"thread_id": "spike-test-1"}}
+
+    # Step 1: Invoke agent — should hit interrupt
+    interrupt_found = False
+    interrupt_value = None
+    async for stream_type, data in agent.astream(
+        {"messages": [("human", "Use the dangerous_tool with query 'hello'")]},
+        config=config,
+        stream_mode=["updates"],
+    ):
+        if stream_type == "updates" and "__interrupt__" in data:
+            interrupt_found = True
+            interrupt_value = data["__interrupt__"][0].value
+
+    assert interrupt_found, "interrupt() was not detected in stream output"
+    assert interrupt_value["tool_name"] == "dangerous_tool"
+    assert interrupt_value["request_id"] == "test-123"
+
+    # Step 2: Resume with approval — Command as first positional arg
+    resumed = False
+    tool_executed = False
+    async for stream_type, data in agent.astream(
+        Command(resume={"approved": True, "request_id": "test-123"}),
+        config=config,
+        stream_mode=["updates"],
+    ):
+        if stream_type == "updates":
+            resumed = True
+            for node_name, updates in data.items():
+                if node_name == "tools":
+                    messages = updates.get("messages", [])
+                    if _check_messages_for(messages, "executed with:"):
+                        tool_executed = True
+
+    assert resumed, "Graph did not resume after Command(resume=...)"
+    assert tool_executed, "Tool was not executed after approval"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_deny_in_middleware():
+    """Verify deny path works — tool returns denial string."""
+    llm = _make_fake_llm()
+    checkpointer = MemorySaver()
+
+    agent = create_agent(
+        model=llm,
+        tools=[dangerous_tool],
+        checkpointer=checkpointer,
+        middleware=[InterruptMiddleware()],
+    )
+
+    config = {"configurable": {"thread_id": "spike-test-2"}}
+
+    # Step 1: Hit interrupt
+    async for _stream_type, _data in agent.astream(
+        {"messages": [("human", "Use the dangerous_tool with query 'test'")]},
+        config=config,
+        stream_mode=["updates"],
+    ):
+        pass  # Just drain to interrupt point
+
+    # Step 2: Resume with denial
+    denied = False
+    async for stream_type, data in agent.astream(
+        Command(resume={"approved": False, "request_id": "test-123"}),
+        config=config,
+        stream_mode=["updates"],
+    ):
+        if stream_type == "updates":
+            for node_name, updates in data.items():
+                if node_name == "tools":
+                    messages = updates.get("messages", [])
+                    if _check_messages_for(messages, "denied"):
+                        denied = True
+
+    assert denied, "Deny path did not return error message"

--- a/tests/unit/test_hitl_agent_stream.py
+++ b/tests/unit/test_hitl_agent_stream.py
@@ -1,0 +1,244 @@
+"""Unit tests for HitL interrupt detection and resume in OpenAIChatAgent."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.agent_service.openai_chat_agent import OpenAIChatAgent
+
+
+def _make_agent() -> OpenAIChatAgent:
+    """Create an agent with mocked internals."""
+    agent = OpenAIChatAgent.__new__(OpenAIChatAgent)
+    agent.agent = MagicMock()
+    agent._mcp_tools = []
+    agent._personas = {}
+    agent.llm = MagicMock()
+    agent.mcp_config = None
+    agent.model_name = "test"
+    agent.temperature = 0
+    agent.top_p = 1
+    return agent
+
+
+async def _fake_astream_with_interrupt(*args, **kwargs):
+    """Simulate astream that hits an interrupt."""
+    yield (
+        "updates",
+        {
+            "__interrupt__": [
+                MagicMock(
+                    value={
+                        "tool_name": "mcp_search",
+                        "tool_args": {"query": "test"},
+                        "request_id": "req-123",
+                    }
+                )
+            ]
+        },
+    )
+
+
+async def _fake_astream_normal(*args, **kwargs):
+    """Simulate normal astream with model output."""
+    yield (
+        "updates",
+        {
+            "model": {"messages": [MagicMock(content="Hello world")]},
+        },
+    )
+
+
+async def _fake_astream_resume_approve(*args, **kwargs):
+    """Simulate resumed astream after approval -- tool executes then model responds."""
+    yield (
+        "updates",
+        {
+            "tools": {"messages": [MagicMock(content="Tool executed successfully")]},
+        },
+    )
+    yield (
+        "updates",
+        {
+            "model": {"messages": [MagicMock(content="Here is the result")]},
+        },
+    )
+
+
+async def _fake_astream_resume_with_second_interrupt(*args, **kwargs):
+    """Simulate resumed astream that hits another interrupt."""
+    yield (
+        "updates",
+        {
+            "tools": {"messages": [MagicMock(content="First tool done")]},
+        },
+    )
+    yield (
+        "updates",
+        {
+            "__interrupt__": [
+                MagicMock(
+                    value={
+                        "tool_name": "mcp_write",
+                        "tool_args": {"data": "important"},
+                        "request_id": "req-456",
+                    }
+                )
+            ]
+        },
+    )
+
+
+# Helper for mocking async iterator
+class AsyncIteratorMock:
+    def __init__(self, items: list):
+        self.items = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.items)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class TestInterruptDetection:
+    """Test __interrupt__ detection in _process_message."""
+
+    @pytest.mark.asyncio
+    async def test_interrupt_detected_in_updates_stream(self):
+        """__interrupt__ in updates stream should yield hitl_request."""
+        agent = _make_agent()
+        agent.agent.astream = _fake_astream_with_interrupt
+
+        events = []
+        async for event in agent._process_message(
+            messages=[],
+            config={"configurable": {"thread_id": "test-session"}},
+        ):
+            events.append(event)
+
+        assert len(events) == 1
+        assert events[0]["type"] == "hitl_request"
+        assert events[0]["tool_name"] == "mcp_search"
+        assert events[0]["tool_args"] == {"query": "test"}
+        assert events[0]["request_id"] == "req-123"
+        assert events[0]["session_id"] == "test-session"
+
+    @pytest.mark.asyncio
+    async def test_hitl_request_event_has_correct_fields(self):
+        """hitl_request should contain request_id, tool_name, tool_args, session_id."""
+        agent = _make_agent()
+        agent.agent.astream = _fake_astream_with_interrupt
+
+        events = []
+        async for event in agent._process_message(
+            messages=[],
+            config={"configurable": {"thread_id": "sess-1"}},
+        ):
+            events.append(event)
+
+        hitl_event = events[0]
+        required_fields = {"type", "request_id", "tool_name", "tool_args", "session_id"}
+        assert required_fields.issubset(hitl_event.keys())
+
+    @pytest.mark.asyncio
+    async def test_stream_exits_after_hitl_request(self):
+        """After hitl_request, _process_message should NOT yield final_response."""
+        agent = _make_agent()
+        agent.agent.astream = _fake_astream_with_interrupt
+
+        events = []
+        async for event in agent._process_message(
+            messages=[],
+            config={"configurable": {"thread_id": "test"}},
+        ):
+            events.append(event)
+
+        event_types = [e["type"] for e in events]
+        assert "final_response" not in event_types
+        assert "stream_end" not in event_types
+
+    @pytest.mark.asyncio
+    async def test_stream_hitl_request_propagated_through_stream(self):
+        """stream() should yield hitl_request and NOT yield stream_end."""
+        agent = _make_agent()
+        agent.agent.astream = _fake_astream_with_interrupt
+
+        events = []
+        async for event in agent.stream(
+            messages=[],
+            session_id="test-session",
+        ):
+            events.append(event)
+
+        event_types = [e["type"] for e in events]
+        assert "stream_start" in event_types
+        assert "hitl_request" in event_types
+        assert "stream_end" not in event_types
+
+
+class TestResumeAfterApproval:
+    """Test resume_after_approval method."""
+
+    @pytest.mark.asyncio
+    async def test_resume_approve_continues_stream(self):
+        """Approved resume should yield tool result and stream_end."""
+        agent = _make_agent()
+        agent.agent.astream = _fake_astream_resume_approve
+
+        events = []
+        async for event in agent.resume_after_approval(
+            session_id="test-session",
+            approved=True,
+            request_id="req-123",
+        ):
+            events.append(event)
+
+        event_types = [e["type"] for e in events]
+        assert "stream_end" in event_types
+
+    @pytest.mark.asyncio
+    async def test_resume_uses_command_as_first_positional_arg(self):
+        """Command(resume=...) should be passed as first positional arg to astream."""
+        agent = _make_agent()
+        agent.agent.astream = AsyncMock(return_value=AsyncIteratorMock([]))
+
+        events = []
+        async for event in agent.resume_after_approval(
+            session_id="sess-1",
+            approved=True,
+            request_id="req-1",
+        ):
+            events.append(event)
+
+        # Check astream was called with Command as first arg
+        call_args = agent.agent.astream.call_args
+        first_arg = call_args[0][0]
+        from langgraph.types import Command
+
+        assert isinstance(first_arg, Command)
+
+    @pytest.mark.asyncio
+    async def test_resume_second_interrupt_yields_another_hitl_request(self):
+        """If resume hits another interrupt, yield another hitl_request."""
+        agent = _make_agent()
+        agent.agent.astream = _fake_astream_resume_with_second_interrupt
+
+        events = []
+        async for event in agent.resume_after_approval(
+            session_id="test-session",
+            approved=True,
+            request_id="req-123",
+        ):
+            events.append(event)
+
+        event_types = [e["type"] for e in events]
+        assert "hitl_request" in event_types
+        hitl_events = [e for e in events if e["type"] == "hitl_request"]
+        assert hitl_events[0]["tool_name"] == "mcp_write"
+        assert hitl_events[0]["request_id"] == "req-456"
+        # Should NOT have stream_end after interrupt
+        assert "stream_end" not in event_types

--- a/tests/unit/test_hitl_event_handling.py
+++ b/tests/unit/test_hitl_event_handling.py
@@ -1,0 +1,362 @@
+"""Unit tests for HitL event handling in WebSocket service layer (Phase 4)."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from src.models.websocket import ErrorMessage
+from src.services.websocket_service.message_processor.models import TurnStatus
+
+
+class TestHitLRequestInProduceAgentEvents:
+    """Tests for hitl_request handling in EventHandler.produce_agent_events."""
+
+    async def test_hitl_request_updates_turn_status_to_awaiting_approval(self):
+        """produce_agent_events with hitl_request event sets turn status to AWAITING_APPROVAL."""
+        from src.services.websocket_service.message_processor.processor import (
+            MessageProcessor,
+        )
+
+        connection_id = uuid4()
+        processor = MessageProcessor(connection_id=connection_id, user_id="test_user")
+
+        async def fake_agent_stream():
+            yield {
+                "type": "hitl_request",
+                "request_id": "req-1",
+                "tool_name": "dangerous_tool",
+                "tool_args": {"x": "1"},
+                "session_id": "sess-1",
+            }
+
+        turn_id = await processor.start_turn(
+            session_id="sess-1",
+            user_input="test",
+            agent_stream=fake_agent_stream(),
+        )
+
+        # Wait for producer to finish processing
+        await asyncio.sleep(0.1)
+
+        turn = processor.turns.get(turn_id)
+        assert turn is not None
+        assert turn.status == TurnStatus.AWAITING_APPROVAL
+
+        await processor.shutdown(cleanup_delay=0)
+
+    async def test_hitl_request_terminates_stream_events(self):
+        """stream_events breaks on hitl_request and does not hang."""
+        from src.services.websocket_service.message_processor.processor import (
+            MessageProcessor,
+        )
+
+        connection_id = uuid4()
+        processor = MessageProcessor(connection_id=connection_id, user_id="test_user")
+
+        async def fake_agent_stream():
+            yield {"type": "stream_start"}
+            yield {
+                "type": "hitl_request",
+                "request_id": "req-1",
+                "tool_name": "tool",
+                "tool_args": {},
+                "session_id": "sess-1",
+            }
+
+        turn_id = await processor.start_turn(
+            session_id="sess-1",
+            user_input="test",
+            agent_stream=fake_agent_stream(),
+        )
+
+        events = []
+        async for event in processor.stream_events(turn_id):
+            events.append(event)
+
+        event_types = [e.get("type") for e in events]
+        assert "hitl_request" in event_types
+        # stream_events should have exited without hanging
+        assert "stream_end" not in event_types
+
+        await processor.shutdown(cleanup_delay=0)
+
+    async def test_hitl_request_no_cleanup_on_stream_events(self):
+        """cleanup is NOT called after hitl_request -- turn stays alive for resume."""
+        from src.services.websocket_service.message_processor.processor import (
+            MessageProcessor,
+        )
+
+        connection_id = uuid4()
+        processor = MessageProcessor(connection_id=connection_id, user_id="test_user")
+
+        async def fake_agent_stream():
+            yield {
+                "type": "hitl_request",
+                "request_id": "req-1",
+                "tool_name": "tool",
+                "tool_args": {},
+                "session_id": "sess-1",
+            }
+
+        turn_id = await processor.start_turn(
+            session_id="sess-1",
+            user_input="test",
+            agent_stream=fake_agent_stream(),
+        )
+
+        events = []
+        async for event in processor.stream_events(turn_id):
+            events.append(event)
+
+        # Turn should still exist and not be cleaned up
+        turn = processor.turns.get(turn_id)
+        assert turn is not None
+        assert turn_id not in processor._cleaned_turns
+        # Current turn ID should still be set (not cleared by cleanup)
+        assert processor._current_turn_id == turn_id
+
+        await processor.shutdown(cleanup_delay=0)
+
+
+class TestTokenStreamClosedResetOnAttach:
+    """Tests for token_stream_closed reset in attach_agent_stream."""
+
+    async def test_token_stream_closed_reset_on_attach_agent_stream(self):
+        """token_stream_closed is reset to False when attaching a new agent stream."""
+        from src.services.websocket_service.message_processor.processor import (
+            MessageProcessor,
+        )
+
+        connection_id = uuid4()
+        processor = MessageProcessor(connection_id=connection_id, user_id="test_user")
+
+        async def fake_hitl_stream():
+            yield {
+                "type": "hitl_request",
+                "request_id": "req-1",
+                "tool_name": "tool",
+                "tool_args": {},
+                "session_id": "sess-1",
+            }
+
+        turn_id = await processor.start_turn(
+            session_id="sess-1",
+            user_input="test",
+            agent_stream=fake_hitl_stream(),
+        )
+
+        # Wait for producer to process hitl_request and signal token stream closed
+        await asyncio.sleep(0.1)
+
+        turn = processor.turns.get(turn_id)
+        assert turn is not None
+        # After hitl_request, token_stream_closed should be True
+        assert turn.token_stream_closed is True
+
+        # Now attach a new stream (simulating resume)
+        async def fake_resume_stream():
+            yield {"type": "stream_start"}
+            yield {"type": "stream_end"}
+
+        await processor.attach_agent_stream(turn_id, fake_resume_stream())
+
+        # token_stream_closed should be reset to False
+        assert turn.token_stream_closed is False
+
+        await processor.shutdown(cleanup_delay=0)
+
+
+class TestHitLResponseHandler:
+    """Tests for handle_hitl_response in MessageHandler."""
+
+    async def test_hitl_response_resumes_agent_stream(self):
+        """handle_hitl_response calls resume_after_approval and attach_agent_stream."""
+        from src.services.websocket_service.manager.handlers import MessageHandler
+
+        # Set up mocks
+        mock_processor = MagicMock()
+        mock_processor._current_turn_id = "turn-1"
+        mock_turn = MagicMock()
+        mock_turn.status = TurnStatus.AWAITING_APPROVAL
+        mock_turn.session_id = "sess-1"
+        mock_processor.turns = {"turn-1": mock_turn}
+        mock_processor.update_turn_status = AsyncMock()
+        mock_processor.attach_agent_stream = AsyncMock()
+        mock_processor.add_task_to_turn = AsyncMock(return_value=True)
+
+        mock_connection = MagicMock()
+        mock_connection.is_authenticated = True
+        mock_connection.message_processor = mock_processor
+
+        get_connection_fn = MagicMock(return_value=mock_connection)
+        send_message_fn = AsyncMock()
+        close_connection_fn = AsyncMock()
+
+        handler = MessageHandler(
+            get_connection_fn, send_message_fn, close_connection_fn
+        )
+
+        mock_agent_service = MagicMock()
+
+        async def fake_resume_stream():
+            yield {"type": "stream_end"}
+
+        mock_agent_service.resume_after_approval = MagicMock(
+            return_value=fake_resume_stream()
+        )
+
+        forward_events_fn = AsyncMock()
+
+        with patch(
+            "src.services.websocket_service.manager.handlers.get_agent_service",
+            return_value=mock_agent_service,
+        ):
+            await handler.handle_hitl_response(
+                connection_id=uuid4(),
+                message_data={"request_id": "req-1", "approved": True},
+                forward_events_fn=forward_events_fn,
+            )
+
+        # Verify status was updated to PROCESSING
+        mock_processor.update_turn_status.assert_called_with(
+            "turn-1", TurnStatus.PROCESSING
+        )
+        # Verify agent stream was attached
+        mock_processor.attach_agent_stream.assert_called_once()
+        # Verify resume_after_approval was called with correct args
+        mock_agent_service.resume_after_approval.assert_called_once_with(
+            session_id="sess-1",
+            approved=True,
+            request_id="req-1",
+        )
+
+    async def test_hitl_response_rejects_when_no_pending_approval(self):
+        """Returns error when turn is not in AWAITING_APPROVAL status."""
+        from src.services.websocket_service.manager.handlers import MessageHandler
+
+        mock_processor = MagicMock()
+        mock_processor._current_turn_id = "turn-1"
+        mock_turn = MagicMock()
+        mock_turn.status = TurnStatus.PROCESSING  # Not AWAITING_APPROVAL
+        mock_processor.turns = {"turn-1": mock_turn}
+
+        mock_connection = MagicMock()
+        mock_connection.is_authenticated = True
+        mock_connection.message_processor = mock_processor
+
+        get_connection_fn = MagicMock(return_value=mock_connection)
+        send_message_fn = AsyncMock()
+        close_connection_fn = AsyncMock()
+
+        handler = MessageHandler(
+            get_connection_fn, send_message_fn, close_connection_fn
+        )
+
+        await handler.handle_hitl_response(
+            connection_id=uuid4(),
+            message_data={"request_id": "req-1", "approved": True},
+            forward_events_fn=AsyncMock(),
+        )
+
+        # Should have sent an error message
+        send_message_fn.assert_called_once()
+        sent_msg = send_message_fn.call_args[0][1]
+        assert isinstance(sent_msg, ErrorMessage)
+        assert "pending approval" in sent_msg.error.lower()
+
+    async def test_hitl_response_rejects_when_no_active_session(self):
+        """Returns error when no message processor exists."""
+        from src.services.websocket_service.manager.handlers import MessageHandler
+
+        mock_connection = MagicMock()
+        mock_connection.is_authenticated = True
+        mock_connection.message_processor = None
+
+        get_connection_fn = MagicMock(return_value=mock_connection)
+        send_message_fn = AsyncMock()
+        close_connection_fn = AsyncMock()
+
+        handler = MessageHandler(
+            get_connection_fn, send_message_fn, close_connection_fn
+        )
+
+        await handler.handle_hitl_response(
+            connection_id=uuid4(),
+            message_data={"request_id": "req-1", "approved": True},
+            forward_events_fn=AsyncMock(),
+        )
+
+        send_message_fn.assert_called_once()
+        sent_msg = send_message_fn.call_args[0][1]
+        assert isinstance(sent_msg, ErrorMessage)
+
+
+class TestWSRoutingHitLResponse:
+    """Tests for HITL_RESPONSE routing in WebSocketManager.handle_message."""
+
+    async def test_ws_routing_hitl_response(self):
+        """websocket_manager routes HITL_RESPONSE to handler."""
+        from src.services.websocket_service.manager.websocket_manager import (
+            WebSocketManager,
+        )
+
+        manager = WebSocketManager()
+
+        # Create a mock connection state
+        connection_id = uuid4()
+        mock_connection = MagicMock()
+        mock_connection.is_authenticated = True
+        mock_connection.message_processor = MagicMock()
+        manager.connections[connection_id] = mock_connection
+
+        # Mock the handler
+        manager._message_handler.handle_hitl_response = AsyncMock()
+
+        raw_message = json.dumps(
+            {
+                "type": "hitl_response",
+                "request_id": "req-1",
+                "approved": True,
+            }
+        )
+
+        await manager.handle_message(connection_id, raw_message)
+
+        # Verify handler was called with correct connection_id
+        manager._message_handler.handle_hitl_response.assert_called_once()
+        call_args = manager._message_handler.handle_hitl_response.call_args
+        assert call_args[0][0] == connection_id
+
+    async def test_ws_routing_hitl_response_requires_auth(self):
+        """HITL_RESPONSE should require authentication."""
+        from src.services.websocket_service.manager.websocket_manager import (
+            WebSocketManager,
+        )
+
+        manager = WebSocketManager()
+
+        connection_id = uuid4()
+        mock_connection = MagicMock()
+        mock_connection.is_authenticated = False
+        mock_connection.message_processor = None
+        manager.connections[connection_id] = mock_connection
+
+        # Mock send_message to capture the error
+        manager.send_message = AsyncMock()
+
+        raw_message = json.dumps(
+            {
+                "type": "hitl_response",
+                "request_id": "req-1",
+                "approved": True,
+            }
+        )
+
+        await manager.handle_message(connection_id, raw_message)
+
+        # Should send auth error, not call handler
+        manager.send_message.assert_called_once()
+        sent_msg = manager.send_message.call_args[0][1]
+        assert isinstance(sent_msg, ErrorMessage)
+        assert "authentication" in sent_msg.error.lower()

--- a/tests/unit/test_hitl_middleware.py
+++ b/tests/unit/test_hitl_middleware.py
@@ -1,0 +1,95 @@
+"""Unit tests for HitLMiddleware."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.agent_service.middleware.hitl_middleware import HitLMiddleware
+
+
+class TestHitLMiddleware:
+    """Test HitL middleware tool classification and interrupt behavior."""
+
+    def _make_middleware(
+        self, mcp_tool_names: set[str] | None = None
+    ) -> HitLMiddleware:
+        """Create middleware with given MCP tool names."""
+        return HitLMiddleware(mcp_tool_names=mcp_tool_names or set())
+
+    def test_safe_tool_passes_through(self):
+        """Built-in tools should pass through without interrupt."""
+        mw = self._make_middleware(mcp_tool_names={"mcp_search"})
+        assert not mw.is_dangerous("memory_search")
+        assert not mw.is_dangerous("update_user_profile")
+        assert not mw.is_dangerous("some_builtin_tool")
+
+    def test_mcp_tool_is_dangerous(self):
+        """MCP tools should be classified as dangerous."""
+        mw = self._make_middleware(mcp_tool_names={"mcp_search", "mcp_write"})
+        assert mw.is_dangerous("mcp_search")
+        assert mw.is_dangerous("mcp_write")
+
+    def test_delegate_tool_is_dangerous(self):
+        """delegate_task tool should always be dangerous."""
+        mw = self._make_middleware()
+        assert mw.is_dangerous("delegate_task")
+
+    def test_builtin_tool_is_safe(self):
+        """Tools not in deny list should be safe."""
+        mw = self._make_middleware(mcp_tool_names={"mcp_tool"})
+        assert not mw.is_dangerous("terminal")
+        assert not mw.is_dangerous("read_file")
+
+    @pytest.mark.asyncio
+    async def test_safe_tool_calls_handler(self):
+        """Safe tools should call handler directly."""
+        mw = self._make_middleware(mcp_tool_names={"mcp_tool"})
+        request = MagicMock()
+        request.tool_call = {"name": "safe_tool", "args": {"key": "value"}}
+        handler = AsyncMock(return_value="tool result")
+
+        result = await mw.awrap_tool_call(request, handler)
+
+        handler.assert_awaited_once_with(request)
+        assert result == "tool result"
+
+    @pytest.mark.asyncio
+    async def test_dangerous_tool_triggers_interrupt(self):
+        """Dangerous tools should call interrupt()."""
+        mw = self._make_middleware(mcp_tool_names={"mcp_search"})
+        request = MagicMock()
+        request.tool_call = {"name": "mcp_search", "args": {"query": "test"}}
+        handler = AsyncMock(return_value="tool result")
+
+        with patch(
+            "src.services.agent_service.middleware.hitl_middleware.interrupt",
+            return_value={"approved": True, "request_id": "test-123"},
+        ) as mock_interrupt:
+            result = await mw.awrap_tool_call(request, handler)
+
+            mock_interrupt.assert_called_once()
+            call_args = mock_interrupt.call_args[0][0]
+            assert call_args["tool_name"] == "mcp_search"
+            assert call_args["tool_args"] == {"query": "test"}
+            assert "request_id" in call_args
+
+        # After approval, handler should be called
+        handler.assert_awaited_once_with(request)
+        assert result == "tool result"
+
+    @pytest.mark.asyncio
+    async def test_deny_returns_error_string(self):
+        """Denied tools should return error string without calling handler."""
+        mw = self._make_middleware(mcp_tool_names={"mcp_search"})
+        request = MagicMock()
+        request.tool_call = {"name": "mcp_search", "args": {}}
+        handler = AsyncMock()
+
+        with patch(
+            "src.services.agent_service.middleware.hitl_middleware.interrupt",
+            return_value={"approved": False, "request_id": "test-456"},
+        ):
+            result = await mw.awrap_tool_call(request, handler)
+
+        handler.assert_not_awaited()
+        assert "denied" in result.lower() or "mcp_search" in result.lower()

--- a/tests/unit/test_hitl_models.py
+++ b/tests/unit/test_hitl_models.py
@@ -1,0 +1,105 @@
+"""Unit tests for HitL message models and turn status."""
+
+from src.models.websocket import (
+    ClientMessage,
+    HitLRequestMessage,
+    HitLResponseMessage,
+    MessageType,
+    ServerMessage,
+)
+from src.services.websocket_service.message_processor.models import TurnStatus
+
+
+class TestHitLMessageTypes:
+    """Test HitL message type enum values."""
+
+    def test_hitl_request_type_exists(self):
+        assert MessageType.HITL_REQUEST == "hitl_request"
+
+    def test_hitl_response_type_exists(self):
+        assert MessageType.HITL_RESPONSE == "hitl_response"
+
+
+class TestHitLRequestMessage:
+    """Test HitLRequestMessage serialization."""
+
+    def test_serialization(self):
+        msg = HitLRequestMessage(
+            request_id="req-123",
+            tool_name="dangerous_tool",
+            tool_args={"query": "hello"},
+            session_id="session-456",
+        )
+        assert msg.type == MessageType.HITL_REQUEST
+        assert msg.request_id == "req-123"
+        assert msg.tool_name == "dangerous_tool"
+        assert msg.tool_args == {"query": "hello"}
+        assert msg.session_id == "session-456"
+
+    def test_json_roundtrip(self):
+        msg = HitLRequestMessage(
+            request_id="req-123",
+            tool_name="test_tool",
+            tool_args={"key": "value"},
+            session_id="sess-1",
+        )
+        data = msg.model_dump()
+        assert data["type"] == "hitl_request"
+        assert data["request_id"] == "req-123"
+
+    def test_in_server_message_union(self):
+        """HitLRequestMessage should be part of ServerMessage union."""
+        msg = HitLRequestMessage(
+            request_id="r1",
+            tool_name="t1",
+            tool_args={},
+            session_id="s1",
+        )
+        # Should be assignable to ServerMessage type
+        server_msg: ServerMessage = msg
+        assert isinstance(server_msg, HitLRequestMessage)
+
+
+class TestHitLResponseMessage:
+    """Test HitLResponseMessage serialization."""
+
+    def test_approve_serialization(self):
+        msg = HitLResponseMessage(
+            request_id="req-123",
+            approved=True,
+        )
+        assert msg.type == MessageType.HITL_RESPONSE
+        assert msg.request_id == "req-123"
+        assert msg.approved is True
+
+    def test_deny_serialization(self):
+        msg = HitLResponseMessage(
+            request_id="req-123",
+            approved=False,
+        )
+        assert msg.approved is False
+
+    def test_in_client_message_union(self):
+        """HitLResponseMessage should be part of ClientMessage union."""
+        msg = HitLResponseMessage(
+            request_id="r1",
+            approved=True,
+        )
+        client_msg: ClientMessage = msg
+        assert isinstance(client_msg, HitLResponseMessage)
+
+
+class TestAwaitingApprovalStatus:
+    """Test AWAITING_APPROVAL turn status."""
+
+    def test_status_exists(self):
+        assert TurnStatus.AWAITING_APPROVAL.value == "awaiting_approval"
+
+    def test_not_terminal(self):
+        """AWAITING_APPROVAL should NOT be in the terminal status set."""
+        terminal_statuses = {
+            TurnStatus.COMPLETED,
+            TurnStatus.INTERRUPTED,
+            TurnStatus.FAILED,
+        }
+        assert TurnStatus.AWAITING_APPROVAL not in terminal_statuses


### PR DESCRIPTION
## Summary

- Implement HitL Phase 1 MVP — LangGraph `interrupt()`-based approval gate that pauses agent execution when invoking dangerous tools (MCP + `delegate_task`), sends `hitl_request` via WebSocket, and waits for user approval/denial before proceeding
- Add `HitLMiddleware` following existing `ToolGateMiddleware` pattern, with shared `_consume_astream` helper for stream processing
- Wire full WS layer: event handling, message routing, turn state management (`AWAITING_APPROVAL`), and graph resume via `Command(resume=...)`

## Changes

### New files
- `src/services/agent_service/middleware/hitl_middleware.py` — middleware calling `interrupt()` for dangerous tools
- `tests/unit/test_hitl_models.py` — 10 tests for message types and turn status
- `tests/unit/test_hitl_middleware.py` — 7 tests for tool classification and interrupt behavior
- `tests/unit/test_hitl_agent_stream.py` — 7 tests for interrupt detection and resume
- `tests/unit/test_hitl_event_handling.py` — 9 tests for WS layer event handling
- `tests/e2e/test_hitl_e2e.py` — 9 E2E tests for full approve/deny/multi-tool flows
- `tests/spike/test_interrupt_in_middleware.py` — spike validating `interrupt()` in middleware

### Modified files
- `src/models/websocket.py` — `HITL_REQUEST/RESPONSE` message types + Pydantic models
- `src/services/agent_service/openai_chat_agent.py` — `_consume_astream` shared helper, `resume_after_approval()`
- `src/services/websocket_service/message_processor/models.py` — `TurnStatus.AWAITING_APPROVAL`
- `src/services/websocket_service/message_processor/event_handlers.py` — `hitl_request` handler in producer
- `src/services/websocket_service/message_processor/processor.py` — `stream_events` hitl termination, `attach_agent_stream` reset, interrupt during approval
- `src/services/websocket_service/manager/handlers.py` — `handle_hitl_response()`
- `src/services/websocket_service/manager/websocket_manager.py` — `HITL_RESPONSE` routing
- `docs/known_issues/KNOWN_ISSUES.md` — KI-22: safe_tool E2E non-determinism

## Test plan

- [x] 33 unit tests passing (models, middleware, agent stream, WS event handling)
- [x] 9 E2E tests (approve, deny, multi-tool, safe tool bypass, existing flow unchanged)
- [x] Lint clean (ruff + black + 23 structural tests)
- [x] Full regression suite: 642 passed, 0 failures
- [x] `bash scripts/e2e.sh` → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)