### PR TITLE
feat: add proactive talking (Phase 1/2/3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "basedpyright>=1.39.0",
     "langchain-community>=0.4.1",
     "ddgs>=9.13.0",
+    "apscheduler>=3.11.2",
 ]
 
 [project.optional-dependencies]

--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
 
-from src.api.routes import callback, ltm, slack, stm, tts, websocket
+from src.api.routes import callback, ltm, proactive, slack, stm, tts, websocket
 from src.models.responses import HealthResponse
 from src.services.health import HealthService, health_service
 
@@ -17,6 +17,7 @@ router.include_router(stm.router)
 router.include_router(ltm.router)
 router.include_router(callback.router)
 router.include_router(slack.router)
+router.include_router(proactive.router)
 
 
 def get_health_service() -> HealthService:

--- a/src/api/routes/proactive.py
+++ b/src/api/routes/proactive.py
@@ -29,14 +29,15 @@ async def trigger_proactive(request: ProactiveTriggerRequest) -> JSONResponse:
             content={"status": "skipped", "reason": "proactive service not available"},
         )
 
-    # Find connection by session_id
-    connection_id: UUID | None = None
-    for cid, _conn in svc._ws_manager.connections.items():
-        if str(cid) == request.session_id:
-            connection_id = cid
-            break
+    try:
+        connection_id = UUID(request.session_id)
+    except ValueError:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"status": "skipped", "reason": "invalid session_id format"},
+        )
 
-    if connection_id is None:
+    if connection_id not in svc._ws_manager.connections:
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
             content={"status": "skipped", "reason": "session not found"},

--- a/src/api/routes/proactive.py
+++ b/src/api/routes/proactive.py
@@ -1,0 +1,56 @@
+"""Proactive talking webhook endpoint."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+from src.models.proactive import ProactiveTriggerRequest, ProactiveTriggerResponse
+from src.services.service_manager import get_proactive_service
+
+router = APIRouter(prefix="/v1/proactive", tags=["Proactive"])
+
+
+@router.post(
+    "/trigger",
+    response_model=ProactiveTriggerResponse,
+    summary="Trigger proactive talk for a session",
+    responses={
+        200: {"description": "Trigger executed or skipped"},
+        503: {"description": "Proactive service not available"},
+    },
+)
+async def trigger_proactive(request: ProactiveTriggerRequest) -> JSONResponse:
+    svc = get_proactive_service()
+    if svc is None:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"status": "skipped", "reason": "proactive service not available"},
+        )
+
+    # Find connection by session_id
+    connection_id: UUID | None = None
+    for cid, _conn in svc._ws_manager.connections.items():
+        if str(cid) == request.session_id:
+            connection_id = cid
+            break
+
+    if connection_id is None:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"status": "skipped", "reason": "session not found"},
+        )
+
+    logger.info(
+        f"Proactive trigger: session={request.session_id} type={request.trigger_type}"
+    )
+
+    result = await svc.trigger_proactive(
+        connection_id=connection_id,
+        trigger_type=request.trigger_type,
+        prompt_key=request.prompt_key,
+        context=request.context,
+    )
+
+    return JSONResponse(status_code=status.HTTP_200_OK, content=result)

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import argparse
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import uvicorn
 import yaml
@@ -16,6 +17,10 @@ from src.api.routes import router as api_router
 from src.configs.settings import get_settings, initialize_settings
 from src.core.logger import setup_logging
 from src.core.middleware import RequestIDMiddleware
+
+if TYPE_CHECKING:
+    from src.services.proactive_service.proactive_service import ProactiveService
+    from src.services.task_sweep_service.sweep import BackgroundSweepService
 
 load_dotenv()
 
@@ -66,7 +71,9 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
 
     settings = get_settings()
 
-    async def _startup() -> "BackgroundSweepService | None":
+    async def _startup() -> (
+        "tuple[BackgroundSweepService | None, ProactiveService | None]"
+    ):
         log_level = os.getenv("LOG_LEVEL", "INFO")
         log_retention = os.getenv("LOG_RETENTION", "30 days")
         setup_logging(level=log_level, retention=log_retention)
@@ -79,6 +86,7 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
         logger.info(f"📊 Log level: {log_level} | Retention: {log_retention}")
 
         sweep_service: BackgroundSweepService | None = None
+        proactive_service: ProactiveService | None = None
 
         try:
             from src.services import (
@@ -163,17 +171,48 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
             except Exception:
                 logger.exception("Failed to start background sweep service")
 
+            # Proactive talking service
+            try:
+                from src.services.service_manager import initialize_proactive_service
+                from src.services.websocket_service.manager import (
+                    websocket_manager as _ws_mgr,
+                )
+
+                agent_svc = get_agent_service()
+                if agent_svc is not None:
+                    proactive_service = initialize_proactive_service(
+                        ws_manager=_ws_mgr,
+                        agent_service=agent_svc,
+                        config_path=svc_config,
+                    )
+                    await proactive_service.start()
+                    logger.info("Proactive service started")
+                else:
+                    logger.warning(
+                        "Proactive service skipped: agent service not available"
+                    )
+            except Exception:
+                logger.exception("Failed to start proactive service")
+
         except Exception:
             logger.exception("⚠️  Failed to initialize services")
 
-        return sweep_service
+        return sweep_service, proactive_service
 
     async def _shutdown(
         sweep_service: "BackgroundSweepService | None",
+        proactive_service: "ProactiveService | None",
     ) -> None:
         logger.info(f"👋 Shutting down {settings.app_name}")
 
-        # Shutdown in reverse init order: sweep → channel → websocket → mongo
+        # Shutdown in reverse init order: proactive → sweep → channel → websocket → mongo
+
+        if proactive_service is not None:
+            try:
+                await proactive_service.stop()
+                logger.info("Proactive service stopped")
+            except Exception:
+                logger.exception("Error stopping proactive service")
 
         if sweep_service is not None:
             try:
@@ -224,9 +263,9 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         """Manage application lifespan events."""
-        sweep_service = await _startup()
+        sweep_service, proactive_service = await _startup()
         yield
-        await _shutdown(sweep_service)
+        await _shutdown(sweep_service, proactive_service)
 
     # Create FastAPI application instance
     app = FastAPI(

--- a/src/models/proactive.py
+++ b/src/models/proactive.py
@@ -1,0 +1,20 @@
+"""Pydantic models for proactive talking webhook API."""
+
+from pydantic import BaseModel, Field
+
+
+class ProactiveTriggerRequest(BaseModel):
+    session_id: str = Field(..., description="Target session/connection ID")
+    trigger_type: str = Field(default="webhook", description="Trigger type identifier")
+    prompt_key: str | None = Field(
+        default=None, description="Prompt template key override"
+    )
+    context: str | None = Field(
+        default=None, description="Additional context injected into prompt"
+    )
+
+
+class ProactiveTriggerResponse(BaseModel):
+    status: str = Field(..., description="'triggered' or 'skipped'")
+    turn_id: str | None = Field(default=None, description="Turn ID if triggered")
+    reason: str | None = Field(default=None, description="Skip reason if skipped")

--- a/src/models/websocket.py
+++ b/src/models/websocket.py
@@ -180,6 +180,7 @@ class StreamStartMessage(BaseMessage):
     type: MessageType = MessageType.STREAM_START
     turn_id: str
     session_id: str
+    proactive: bool | None = None
 
 
 class StreamTokenMessage(BaseMessage):

--- a/src/services/proactive_service/__init__.py
+++ b/src/services/proactive_service/__init__.py
@@ -1,0 +1,1 @@
+"""Proactive Talking Service — idle watcher, scheduler, and webhook trigger."""

--- a/src/services/proactive_service/__init__.py
+++ b/src/services/proactive_service/__init__.py
@@ -1,1 +1,5 @@
-"""Proactive Talking Service — idle watcher, scheduler, and webhook trigger."""
+"""Proactive talking service — AI-initiated conversation triggers."""
+
+from src.services.proactive_service.proactive_service import ProactiveService
+
+__all__ = ["ProactiveService"]

--- a/src/services/proactive_service/config.py
+++ b/src/services/proactive_service/config.py
@@ -1,0 +1,17 @@
+"""Configuration models for the ProactiveService."""
+
+from pydantic import BaseModel, Field
+
+
+class ScheduleEntry(BaseModel):
+    id: str = Field(..., description="Unique schedule identifier")
+    cron: str = Field(..., description="Cron expression")
+    prompt_key: str = Field(..., description="Key in proactive_prompts.yml")
+    enabled: bool = Field(default=True)
+
+
+class ProactiveConfig(BaseModel):
+    idle_timeout_seconds: int = Field(default=300, ge=1)
+    cooldown_seconds: int = Field(default=600, ge=0)
+    watcher_interval_seconds: int = Field(default=30, ge=1)
+    schedules: list[ScheduleEntry] = Field(default_factory=list)

--- a/src/services/proactive_service/idle_watcher.py
+++ b/src/services/proactive_service/idle_watcher.py
@@ -1,0 +1,96 @@
+"""Idle connection watcher — triggers proactive talk after inactivity."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from loguru import logger
+
+from src.services.proactive_service.config import ProactiveConfig
+
+if TYPE_CHECKING:
+    from src.services.websocket_service.manager.connection import ConnectionState
+
+
+class IdleWatcher:
+    """Periodically scans connections for idle users."""
+
+    def __init__(
+        self,
+        config: ProactiveConfig,
+        get_connections_fn: Callable[[], dict[UUID, ConnectionState]],
+        trigger_fn: Callable[..., Any],
+        persona_overrides: dict[str, int] | None = None,
+    ):
+        self._config = config
+        self._get_connections = get_connections_fn
+        self._trigger = trigger_fn
+        self._persona_overrides = persona_overrides or {}
+        self._task: asyncio.Task | None = None
+        self._triggered_connections: set[UUID] = set()
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(self._loop(), name="idle_watcher_loop")
+
+    async def stop(self) -> None:
+        if self._task is None or self._task.done():
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await self.scan_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("IdleWatcher: unhandled error during scan")
+            await asyncio.sleep(self._config.watcher_interval_seconds)
+
+    async def scan_once(
+        self,
+        get_persona_fn: Callable[[UUID], str] | None = None,
+    ) -> None:
+        """Scan all connections and trigger proactive talk for idle ones."""
+        now = time.time()
+        connections = self._get_connections()
+
+        for connection_id, conn in connections.items():
+            if not conn.is_authenticated or conn.is_closing:
+                continue
+            mp = conn.message_processor
+            if not mp or mp._current_turn_id is not None:
+                continue
+
+            timeout = self._config.idle_timeout_seconds
+            if get_persona_fn is not None:
+                persona = get_persona_fn(connection_id)
+                if persona in self._persona_overrides:
+                    timeout = self._persona_overrides[persona]
+
+            idle_seconds = now - conn.last_user_message_at
+            if idle_seconds < timeout:
+                self._triggered_connections.discard(connection_id)
+                continue
+
+            if connection_id in self._triggered_connections:
+                continue
+
+            self._triggered_connections.add(connection_id)
+            await self._trigger(
+                connection_id=connection_id,
+                trigger_type="idle",
+                idle_seconds=int(idle_seconds),
+            )
+
+    def reset_connection(self, connection_id: UUID) -> None:
+        self._triggered_connections.discard(connection_id)

--- a/src/services/proactive_service/idle_watcher.py
+++ b/src/services/proactive_service/idle_watcher.py
@@ -26,11 +26,13 @@ class IdleWatcher:
         get_connections_fn: Callable[[], dict[UUID, ConnectionState]],
         trigger_fn: Callable[..., Any],
         persona_overrides: dict[str, int] | None = None,
+        get_persona_fn: Callable[[UUID], str] | None = None,
     ):
         self._config = config
         self._get_connections = get_connections_fn
         self._trigger = trigger_fn
         self._persona_overrides = persona_overrides or {}
+        self._get_persona_fn = get_persona_fn
         self._task: asyncio.Task | None = None
         self._triggered_connections: set[UUID] = set()
 
@@ -49,7 +51,7 @@ class IdleWatcher:
     async def _loop(self) -> None:
         while True:
             try:
-                await self.scan_once()
+                await self.scan_once(get_persona_fn=self._get_persona_fn)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -64,6 +66,8 @@ class IdleWatcher:
         now = time.time()
         connections = self._get_connections()
 
+        self._triggered_connections &= connections.keys()
+
         for connection_id, conn in connections.items():
             if not conn.is_authenticated or conn.is_closing:
                 continue
@@ -72,8 +76,9 @@ class IdleWatcher:
                 continue
 
             timeout = self._config.idle_timeout_seconds
-            if get_persona_fn is not None:
-                persona = get_persona_fn(connection_id)
+            effective_fn = get_persona_fn or self._get_persona_fn
+            if effective_fn is not None:
+                persona = effective_fn(connection_id)
                 if persona in self._persona_overrides:
                     timeout = self._persona_overrides[persona]
 

--- a/src/services/proactive_service/proactive_service.py
+++ b/src/services/proactive_service/proactive_service.py
@@ -47,6 +47,10 @@ class ProactiveService:
             get_connections_fn=lambda: self._ws_manager.connections,
             trigger_fn=self.trigger_proactive,
             persona_overrides=self._persona_overrides,
+            get_persona_fn=lambda cid: (
+                getattr(self._ws_manager.connections.get(cid), "persona_id", "yuri")
+                or "yuri"
+            ),
         )
         self._schedule_manager = ScheduleManager(
             config=config,
@@ -83,6 +87,13 @@ class ProactiveService:
         conn = self._ws_manager.connections.get(connection_id)
         if conn is None or conn.is_closing:
             return {"status": "skipped", "reason": "connection not found"}
+
+        # Prune stale cooldown entries for disconnected connections
+        known = set(self._ws_manager.connections.keys())
+        if len(self._last_proactive_at) > len(known):
+            self._last_proactive_at = {
+                k: v for k, v in self._last_proactive_at.items() if k in known
+            }
 
         # 2. Active turn check
         mp = conn.message_processor
@@ -124,7 +135,7 @@ class ProactiveService:
             agent_stream = self._agent_service.stream(
                 messages=[SystemMessage(content=prompt_text)],
                 session_id=str(connection_id),
-                persona_id="",
+                persona_id=conn.persona_id,
                 user_id=conn.user_id or "unknown",
                 agent_id="proactive",
                 is_new_session=False,

--- a/src/services/proactive_service/proactive_service.py
+++ b/src/services/proactive_service/proactive_service.py
@@ -1,0 +1,156 @@
+"""ProactiveService — orchestrates all proactive talking triggers."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from loguru import logger
+
+from src.services.proactive_service.config import ProactiveConfig
+from src.services.proactive_service.idle_watcher import IdleWatcher
+from src.services.proactive_service.prompt_loader import PromptLoader
+from src.services.proactive_service.schedule_manager import ScheduleManager
+
+if TYPE_CHECKING:
+    from src.services.agent_service.service import AgentService
+    from src.services.websocket_service.manager.websocket_manager import (
+        WebSocketManager,
+    )
+
+
+class ProactiveService:
+    """Orchestrates idle watcher, schedule manager, and prompt rendering
+    to deliver proactive messages to connected users."""
+
+    def __init__(
+        self,
+        config: ProactiveConfig,
+        ws_manager: WebSocketManager,
+        agent_service: AgentService,
+        prompts_path: Path | None = None,
+        persona_overrides: dict[str, int] | None = None,
+    ):
+        self._config = config
+        self._ws_manager = ws_manager
+        self._agent_service = agent_service
+        self._prompt_loader = PromptLoader(prompts_path)
+        self._persona_overrides = persona_overrides or {}
+        self._last_proactive_at: dict[UUID, float] = {}
+
+        self._idle_watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: self._ws_manager.connections,
+            trigger_fn=self.trigger_proactive,
+            persona_overrides=self._persona_overrides,
+        )
+        self._schedule_manager = ScheduleManager(
+            config=config,
+            trigger_fn=self.trigger_proactive,
+            get_connections_fn=lambda: self._ws_manager.connections,
+        )
+
+    async def start(self) -> None:
+        """Start idle watcher and schedule manager."""
+        await self._idle_watcher.start()
+        await self._schedule_manager.start()
+        logger.info("ProactiveService started")
+
+    async def stop(self) -> None:
+        """Stop idle watcher and schedule manager."""
+        await self._idle_watcher.stop()
+        await self._schedule_manager.stop()
+        logger.info("ProactiveService stopped")
+
+    async def trigger_proactive(
+        self,
+        connection_id: UUID,
+        trigger_type: str,
+        prompt_key: str | None = None,
+        context: str | None = None,
+        idle_seconds: int | None = None,
+    ) -> dict[str, str]:
+        """Execute a proactive trigger for a specific connection.
+
+        Returns {"status": "triggered", "turn_id": "..."} on success,
+        or {"status": "skipped", "reason": "..."} when skipped.
+        """
+        # 1. Connection check
+        conn = self._ws_manager.connections.get(connection_id)
+        if conn is None or conn.is_closing:
+            return {"status": "skipped", "reason": "connection not found"}
+
+        # 2. Active turn check
+        mp = conn.message_processor
+        if not mp or mp._current_turn_id is not None:
+            return {"status": "skipped", "reason": "active turn in progress"}
+
+        # 3. Idle recheck — only for idle triggers
+        now = time.time()
+        if trigger_type == "idle":
+            timeout = self._persona_overrides.get(
+                "default", self._config.idle_timeout_seconds
+            )
+            if now - conn.last_user_message_at < timeout:
+                return {"status": "skipped", "reason": "connection became active"}
+
+        # 4. Cooldown
+        last_at = self._last_proactive_at.get(connection_id, 0)
+        if now - last_at < self._config.cooldown_seconds:
+            remaining = int(self._config.cooldown_seconds - (now - last_at))
+            return {
+                "status": "skipped",
+                "reason": f"cooldown active ({remaining}s remaining)",
+            }
+
+        # 5. Render prompt
+        effective_key = prompt_key or trigger_type
+        current_time = datetime.now().strftime("%H:%M:%S")
+        prompt_text = self._prompt_loader.render(
+            effective_key,
+            idle_seconds=idle_seconds or 0,
+            current_time=current_time,
+            context=context or "",
+        )
+
+        # 6-7. Stream agent response + forward to client WebSocket
+        try:
+            from langchain_core.messages import SystemMessage
+
+            agent_stream = self._agent_service.stream(
+                messages=[SystemMessage(content=prompt_text)],
+                session_id=str(connection_id),
+                persona_id="",
+                user_id=conn.user_id or "unknown",
+                agent_id="proactive",
+                is_new_session=False,
+            )
+
+            turn_id: str | None = None
+            websocket = conn.websocket
+            async for event in agent_stream:
+                event["proactive"] = True
+                if event.get("type") == "stream_start":
+                    turn_id = event.get("turn_id", "")
+                event_json = json.dumps(event, default=str)
+                await websocket.send_text(event_json)
+
+            # 8. Update cooldown timestamp
+            self._last_proactive_at[connection_id] = time.time()
+            logger.info(
+                f"Proactive {trigger_type} triggered for {connection_id} "
+                f"(turn_id={turn_id})"
+            )
+            return {"status": "triggered", "turn_id": turn_id or ""}
+
+        except Exception as exc:
+            logger.exception(f"Proactive trigger failed for {connection_id}: {exc}")
+            return {"status": "skipped", "reason": f"error: {exc}"}
+
+    def on_user_message(self, connection_id: UUID) -> None:
+        """Reset idle tracking when a user sends a message."""
+        self._idle_watcher.reset_connection(connection_id)

--- a/src/services/proactive_service/prompt_loader.py
+++ b/src/services/proactive_service/prompt_loader.py
@@ -1,0 +1,49 @@
+"""YAML-based prompt template loader for proactive triggers."""
+
+from pathlib import Path
+
+import yaml
+from loguru import logger
+
+_DEFAULT_PROMPTS_PATH = (
+    Path(__file__).resolve().parents[3] / "yaml_files" / "proactive_prompts.yml"
+)
+
+
+class PromptLoader:
+    """Loads and renders proactive prompt templates from YAML."""
+
+    def __init__(self, prompts_path: Path | None = None):
+        self._path = prompts_path or _DEFAULT_PROMPTS_PATH
+        self._templates: dict[str, str] = {}
+        self.reload()
+
+    def reload(self) -> None:
+        """(Re)load prompt templates from YAML file."""
+        if not self._path.exists():
+            logger.warning(f"Proactive prompts file not found: {self._path}")
+            self._templates = {}
+            return
+        with open(self._path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        self._templates = {k: str(v) for k, v in data.items()}
+        logger.info(f"Loaded {len(self._templates)} proactive prompt templates")
+
+    def render(self, trigger_type: str, **kwargs: object) -> str:
+        """Render a prompt template.
+
+        Missing template → fallback string.
+        Missing variables → left as placeholder (e.g. {key}).
+        """
+        template = self._templates.get(trigger_type)
+        if template is None:
+            logger.warning(f"No prompt template for trigger type: {trigger_type}")
+            return f"Proactive trigger: {trigger_type}"
+        return template.format_map(_SafeDict(kwargs))
+
+
+class _SafeDict(dict):
+    """Dict subclass that returns '{key}' for missing keys."""
+
+    def __missing__(self, key: str) -> str:
+        return f"{{{key}}}"

--- a/src/services/proactive_service/schedule_manager.py
+++ b/src/services/proactive_service/schedule_manager.py
@@ -1,0 +1,71 @@
+"""APScheduler-based schedule manager for time-triggered proactive talks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from loguru import logger
+
+from src.services.proactive_service.config import ProactiveConfig
+
+if TYPE_CHECKING:
+    from src.services.websocket_service.manager.connection import ConnectionState
+
+
+class ScheduleManager:
+    def __init__(
+        self,
+        config: ProactiveConfig,
+        trigger_fn: Callable[..., Any],
+        get_connections_fn: Callable[[], dict[UUID, ConnectionState]],
+    ):
+        self._config = config
+        self._trigger = trigger_fn
+        self._get_connections = get_connections_fn
+        self._scheduler = AsyncIOScheduler()
+
+    async def start(self) -> None:
+        for entry in self._config.schedules:
+            if not entry.enabled:
+                logger.info(f"Schedule '{entry.id}' is disabled, skipping")
+                continue
+            try:
+                trigger = CronTrigger.from_crontab(entry.cron)
+                self._scheduler.add_job(
+                    self._on_schedule_fire,
+                    trigger=trigger,
+                    id=f"proactive_{entry.id}",
+                    kwargs={"schedule_id": entry.id, "prompt_key": entry.prompt_key},
+                    replace_existing=True,
+                )
+            except Exception:
+                logger.exception(f"Failed to register schedule '{entry.id}'")
+        self._scheduler.start()
+
+    async def stop(self) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+
+    def is_running(self) -> bool:
+        return self._scheduler.running
+
+    async def _on_schedule_fire(self, schedule_id: str, prompt_key: str) -> None:
+        connections = self._get_connections()
+        active = {
+            cid: c
+            for cid, c in connections.items()
+            if c.is_authenticated and not c.is_closing
+        }
+        if not active:
+            logger.info(f"Schedule '{schedule_id}' fired but no active connections")
+            return
+        for connection_id in active:
+            await self._trigger(
+                connection_id=connection_id,
+                trigger_type="scheduled",
+                prompt_key=prompt_key,
+            )

--- a/src/services/service_manager.py
+++ b/src/services/service_manager.py
@@ -12,8 +12,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
+    from src.services.agent_service.service import AgentService as AgentService
     from src.services.channel_service.slack_service import SlackService, SlackSettings
+    from src.services.proactive_service.proactive_service import ProactiveService
     from src.services.task_sweep_service.sweep import BackgroundSweepService
+    from src.services.websocket_service.manager.websocket_manager import (
+        WebSocketManager,
+    )
 
 import pymongo as _pymongo
 import yaml
@@ -40,6 +45,7 @@ _session_registry_instance: "SessionRegistry | None" = None
 _pending_task_repo_instance: PendingTaskRepository | None = None
 _user_profile_service_instance: UserProfileService | None = None
 _summary_service_instance: SummaryService | None = None
+_proactive_service_instance: "ProactiveService | None" = None
 
 T = TypeVar("T")
 
@@ -628,12 +634,73 @@ def initialize_sweep_service(
     )
 
 
+def initialize_proactive_service(
+    ws_manager: "WebSocketManager",
+    agent_service: "AgentService",
+    config_path: str | Path | None = None,
+) -> "ProactiveService":
+    """Build ProactiveService from YAML configuration.
+
+    Reads the ``proactive`` section from the services YAML config and optionally
+    loads per-persona ``idle_timeout_seconds`` overrides from personas.yml.
+
+    Args:
+        ws_manager: Initialized WebSocketManager instance (required).
+        agent_service: Initialized AgentService instance (required).
+        config_path: Path to services YAML config. If None, uses default.
+
+    Returns:
+        Configured ProactiveService (not yet started).
+    """
+    global _proactive_service_instance
+
+    from src.services.proactive_service.config import ProactiveConfig
+    from src.services.proactive_service.proactive_service import ProactiveService
+
+    proactive_cfg_dict = _load_service_yaml(
+        service_name="Proactive",
+        default_config_path=_BASE_YAML / "services.yml",
+        config_key="proactive",
+        config_path=config_path,
+    )
+
+    # Extract persona overrides from personas.yml
+    persona_overrides: dict[str, int] = {}
+    try:
+        personas_path = _BASE_YAML / "personas.yml"
+        if personas_path.exists():
+            with open(personas_path, encoding="utf-8") as f:
+                personas_data = yaml.safe_load(f) or {}
+            for pid, pdata in personas_data.get("personas", {}).items():
+                if "idle_timeout_seconds" in pdata:
+                    persona_overrides[pid] = pdata["idle_timeout_seconds"]
+    except Exception:
+        logger.exception("Failed to load persona idle_timeout overrides")
+
+    config = ProactiveConfig(**proactive_cfg_dict)
+
+    _proactive_service_instance = ProactiveService(
+        config=config,
+        ws_manager=ws_manager,
+        agent_service=agent_service,
+        persona_overrides=persona_overrides,
+    )
+    logger.info("ProactiveService initialized")
+    return _proactive_service_instance
+
+
+def get_proactive_service() -> "ProactiveService | None":
+    """Get the initialized ProactiveService instance."""
+    return _proactive_service_instance
+
+
 __all__ = [
     "get_agent_service",
     "get_emotion_motion_mapper",
     "get_ltm_service",
     "get_mongo_client",
     "get_mongo_db",
+    "get_proactive_service",
     "get_session_registry",
     "get_summary_service",
     "get_tts_service",
@@ -643,6 +710,7 @@ __all__ = [
     "initialize_emotion_motion_mapper",
     "initialize_ltm_service",
     "initialize_mongodb_client",
+    "initialize_proactive_service",
     "initialize_services",
     "initialize_summary_service",
     "initialize_sweep_service",

--- a/src/services/websocket_service/manager/connection.py
+++ b/src/services/websocket_service/manager/connection.py
@@ -26,4 +26,5 @@ class ConnectionState:
         self.last_pong_time: float | None = None
         self.user_id: str | None = None
         self.created_at = time.time()
+        self.last_user_message_at: float = self.created_at
         self.message_processor: MessageProcessor | None = None

--- a/src/services/websocket_service/manager/connection.py
+++ b/src/services/websocket_service/manager/connection.py
@@ -25,6 +25,7 @@ class ConnectionState:
         self.last_ping_time: float | None = None
         self.last_pong_time: float | None = None
         self.user_id: str | None = None
+        self.persona_id: str = "yuri"
         self.created_at = time.time()
         self.last_user_message_at: float = self.created_at
         self.message_processor: MessageProcessor | None = None

--- a/src/services/websocket_service/manager/handlers.py
+++ b/src/services/websocket_service/manager/handlers.py
@@ -160,6 +160,7 @@ class MessageHandler:
             agent_id = message_data.get("agent_id")
             user_id = message_data.get("user_id")
             persona_id = message_data.get("persona_id", "yuri")
+            connection_state.persona_id = persona_id
             # Extract session_id from client (None for new conversations)
             session_id = message_data.get("session_id")
             message_data.get("limit", 10)

--- a/src/services/websocket_service/manager/handlers.py
+++ b/src/services/websocket_service/manager/handlers.py
@@ -139,6 +139,11 @@ class MessageHandler:
             )
             return
 
+        # Update idle tracking timestamp
+        import time as _time
+
+        connection_state.last_user_message_at = _time.time()
+
         agent_service = get_agent_service()
 
         if agent_service is None:

--- a/tests/api/test_proactive_route.py
+++ b/tests/api/test_proactive_route.py
@@ -1,0 +1,66 @@
+"""Tests for POST /v1/proactive/trigger endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes.proactive import router
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+class TestProactiveTriggerEndpoint:
+    def test_missing_session_id_returns_422(self, client):
+        resp = client.post("/v1/proactive/trigger", json={"trigger_type": "webhook"})
+        assert resp.status_code == 422
+
+    @patch("src.api.routes.proactive.get_proactive_service")
+    def test_service_not_available_returns_503(self, mock_get, client):
+        mock_get.return_value = None
+        resp = client.post(
+            "/v1/proactive/trigger",
+            json={"session_id": "test-session", "trigger_type": "webhook"},
+        )
+        assert resp.status_code == 503
+
+    @patch("src.api.routes.proactive.get_proactive_service")
+    def test_session_not_found_returns_404(self, mock_get, client):
+        mock_svc = MagicMock()
+        mock_svc._ws_manager.connections = {}
+        mock_get.return_value = mock_svc
+        resp = client.post(
+            "/v1/proactive/trigger",
+            json={"session_id": str(uuid4()), "trigger_type": "webhook"},
+        )
+        assert resp.status_code == 404
+
+    @patch("src.api.routes.proactive.get_proactive_service")
+    def test_successful_trigger(self, mock_get, client):
+        mock_svc = MagicMock()
+        conn_id = uuid4()
+        mock_conn = MagicMock()
+        mock_svc._ws_manager.connections = {conn_id: mock_conn}
+        mock_svc.trigger_proactive = AsyncMock(
+            return_value={"status": "triggered", "turn_id": "t1"}
+        )
+        mock_get.return_value = mock_svc
+
+        resp = client.post(
+            "/v1/proactive/trigger",
+            json={"session_id": str(conn_id), "trigger_type": "webhook"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "triggered"

--- a/tests/api/test_proactive_route.py
+++ b/tests/api/test_proactive_route.py
@@ -48,6 +48,16 @@ class TestProactiveTriggerEndpoint:
         assert resp.status_code == 404
 
     @patch("src.api.routes.proactive.get_proactive_service")
+    def test_invalid_session_id_format_returns_400(self, mock_get, client):
+        mock_svc = MagicMock()
+        mock_get.return_value = mock_svc
+        resp = client.post(
+            "/v1/proactive/trigger",
+            json={"session_id": "not-a-uuid", "trigger_type": "webhook"},
+        )
+        assert resp.status_code == 400
+
+    @patch("src.api.routes.proactive.get_proactive_service")
     def test_successful_trigger(self, mock_get, client):
         mock_svc = MagicMock()
         conn_id = uuid4()

--- a/tests/e2e/test_proactive_e2e.py
+++ b/tests/e2e/test_proactive_e2e.py
@@ -1,0 +1,131 @@
+"""E2E tests for proactive talking feature.
+
+Requires: FASTAPI_URL env var pointing to a running backend.
+    FASTAPI_URL=http://127.0.0.1:7123 uv run pytest -m e2e tests/e2e/test_proactive_e2e.py --tb=long
+"""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+import websockets
+
+TOKEN = "demo-token"
+CONNECT_TIMEOUT = 10
+RECV_TIMEOUT = 30.0
+
+
+@pytest.mark.e2e
+class TestProactiveWebhookE2E:
+    async def test_webhook_trigger_sends_proactive_message(self, e2e_session):
+        """POST /v1/proactive/trigger → WS receives proactive-tagged events."""
+        base_url = e2e_session["base_url"]
+        ws_url = e2e_session["ws_url"]
+
+        async with websockets.connect(
+            ws_url,
+            open_timeout=CONNECT_TIMEOUT,
+            ping_interval=20,
+            ping_timeout=10,
+            close_timeout=5,
+        ) as ws:
+            await ws.send(json.dumps({"type": "authorize", "token": TOKEN}))
+            connection_id = None
+
+            while True:
+                raw = await asyncio.wait_for(ws.recv(), timeout=RECV_TIMEOUT)
+                data = json.loads(raw)
+                if data.get("type") == "ping":
+                    await ws.send(json.dumps({"type": "pong"}))
+                    continue
+                if data.get("type") == "authorize_success":
+                    connection_id = data.get("connection_id")
+                    break
+                if data.get("type") == "authorize_error":
+                    pytest.fail(f"Auth failed: {data}")
+
+            assert connection_id is not None
+
+            async with httpx.AsyncClient() as http:
+                resp = await http.post(
+                    f"{base_url}/v1/proactive/trigger",
+                    json={
+                        "session_id": connection_id,
+                        "trigger_type": "webhook",
+                        "context": "E2E test trigger",
+                    },
+                )
+                assert resp.status_code == 200
+                trigger_result = resp.json()
+
+            if trigger_result.get("status") == "skipped":
+                pytest.skip(f"Trigger skipped: {trigger_result.get('reason')}")
+
+            events = []
+            try:
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=RECV_TIMEOUT)
+                    data = json.loads(raw)
+                    if data.get("type") == "ping":
+                        await ws.send(json.dumps({"type": "pong"}))
+                        continue
+                    events.append(data)
+                    if data.get("type") == "stream_end":
+                        break
+            except TimeoutError:
+                pytest.fail(
+                    f"Timed out waiting for proactive stream_end. Events: {events}"
+                )
+
+            event_types = [e["type"] for e in events]
+            assert "stream_start" in event_types
+            assert "stream_end" in event_types
+            stream_start = next(e for e in events if e["type"] == "stream_start")
+            assert stream_start.get("proactive") is True
+
+
+@pytest.mark.e2e
+class TestProactiveIdleE2E:
+    async def test_idle_triggers_proactive_message(self, e2e_session):
+        """Connect → wait idle_timeout → receive proactive message."""
+        ws_url = e2e_session["ws_url"]
+
+        async with websockets.connect(
+            ws_url,
+            open_timeout=CONNECT_TIMEOUT,
+            ping_interval=20,
+            ping_timeout=10,
+            close_timeout=5,
+        ) as ws:
+            await ws.send(json.dumps({"type": "authorize", "token": TOKEN}))
+
+            while True:
+                raw = await asyncio.wait_for(ws.recv(), timeout=RECV_TIMEOUT)
+                data = json.loads(raw)
+                if data.get("type") == "ping":
+                    await ws.send(json.dumps({"type": "pong"}))
+                    continue
+                if data.get("type") == "authorize_success":
+                    break
+
+            events = []
+            try:
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=15.0)
+                    data = json.loads(raw)
+                    if data.get("type") == "ping":
+                        await ws.send(json.dumps({"type": "pong"}))
+                        continue
+                    events.append(data)
+                    if data.get("type") == "stream_end":
+                        break
+            except TimeoutError:
+                if not events:
+                    pytest.fail("No proactive message received within 15s idle period")
+
+            if events:
+                event_types = [e["type"] for e in events]
+                assert "stream_start" in event_types
+                stream_start = next(e for e in events if e["type"] == "stream_start")
+                assert stream_start.get("proactive") is True

--- a/tests/services/proactive_service/test_config.py
+++ b/tests/services/proactive_service/test_config.py
@@ -1,0 +1,113 @@
+"""Tests for ProactiveConfig and ScheduleEntry models."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.services.proactive_service.config import ProactiveConfig, ScheduleEntry
+
+# ---------------------------------------------------------------------------
+# ScheduleEntry tests
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleEntry:
+    def test_valid_schedule(self):
+        """A valid ScheduleEntry with all required fields should construct without error."""
+        entry = ScheduleEntry(
+            id="morning_greeting",
+            cron="0 9 * * *",
+            prompt_key="morning",
+        )
+        assert entry.id == "morning_greeting"
+        assert entry.cron == "0 9 * * *"
+        assert entry.prompt_key == "morning"
+
+    def test_enabled_true_by_default(self):
+        """ScheduleEntry.enabled must default to True."""
+        entry = ScheduleEntry(id="test", cron="* * * * *", prompt_key="idle")
+        assert entry.enabled is True
+
+    def test_enabled_can_be_set_false(self):
+        """ScheduleEntry.enabled can be explicitly set to False."""
+        entry = ScheduleEntry(
+            id="test", cron="* * * * *", prompt_key="idle", enabled=False
+        )
+        assert entry.enabled is False
+
+    def test_missing_required_field_raises(self):
+        """Missing required fields (id, cron, prompt_key) must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ScheduleEntry(cron="* * * * *", prompt_key="idle")  # missing id
+
+
+# ---------------------------------------------------------------------------
+# ProactiveConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveConfig:
+    def test_defaults_are_reasonable(self):
+        """Default values must be positive and within expected ranges."""
+        cfg = ProactiveConfig()
+        assert cfg.idle_timeout_seconds == 300
+        assert cfg.cooldown_seconds == 600
+        assert cfg.watcher_interval_seconds == 30
+        assert cfg.schedules == []
+
+    def test_custom_values(self):
+        """Custom values must be stored correctly."""
+        cfg = ProactiveConfig(
+            idle_timeout_seconds=180,
+            cooldown_seconds=120,
+            watcher_interval_seconds=10,
+            schedules=[
+                ScheduleEntry(id="morning", cron="0 9 * * *", prompt_key="morning")
+            ],
+        )
+        assert cfg.idle_timeout_seconds == 180
+        assert cfg.cooldown_seconds == 120
+        assert cfg.watcher_interval_seconds == 10
+        assert len(cfg.schedules) == 1
+        assert cfg.schedules[0].id == "morning"
+
+    def test_minimum_values_enforced_idle_timeout(self):
+        """idle_timeout_seconds must be >= 1; value of 0 must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ProactiveConfig(idle_timeout_seconds=0)
+
+    def test_minimum_values_enforced_watcher_interval(self):
+        """watcher_interval_seconds must be >= 1; value of 0 must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ProactiveConfig(watcher_interval_seconds=0)
+
+    def test_cooldown_seconds_can_be_zero(self):
+        """cooldown_seconds is >= 0, so 0 is a valid value."""
+        cfg = ProactiveConfig(cooldown_seconds=0)
+        assert cfg.cooldown_seconds == 0
+
+    def test_cooldown_seconds_negative_raises(self):
+        """cooldown_seconds must be >= 0; negative value must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ProactiveConfig(cooldown_seconds=-1)
+
+    def test_schedules_default_is_empty_list(self):
+        """schedules must default to an empty list (not None or shared mutable)."""
+        cfg1 = ProactiveConfig()
+        cfg2 = ProactiveConfig()
+        assert cfg1.schedules == []
+        cfg1.schedules.append(
+            ScheduleEntry(id="x", cron="* * * * *", prompt_key="idle")
+        )
+        assert cfg2.schedules == [], "default_factory must produce independent lists"
+
+    def test_multiple_schedules(self):
+        """Multiple ScheduleEntry items must all be stored correctly."""
+        entries = [
+            ScheduleEntry(id="morning", cron="0 9 * * *", prompt_key="morning"),
+            ScheduleEntry(
+                id="evening", cron="0 18 * * *", prompt_key="idle", enabled=False
+            ),
+        ]
+        cfg = ProactiveConfig(schedules=entries)
+        assert len(cfg.schedules) == 2
+        assert cfg.schedules[1].enabled is False

--- a/tests/services/proactive_service/test_idle_watcher.py
+++ b/tests/services/proactive_service/test_idle_watcher.py
@@ -1,0 +1,21 @@
+"""Tests for idle watcher and ConnectionState timestamp."""
+
+import time
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from src.services.websocket_service.manager.connection import ConnectionState
+
+
+class TestConnectionStateTimestamp:
+    def test_last_user_message_at_initialized_to_created_at(self):
+        ws = MagicMock()
+        conn = ConnectionState(ws, uuid4())
+        assert conn.last_user_message_at == conn.created_at
+
+    def test_last_user_message_at_is_updatable(self):
+        ws = MagicMock()
+        conn = ConnectionState(ws, uuid4())
+        now = time.time()
+        conn.last_user_message_at = now
+        assert conn.last_user_message_at == now

--- a/tests/services/proactive_service/test_idle_watcher.py
+++ b/tests/services/proactive_service/test_idle_watcher.py
@@ -22,6 +22,11 @@ class TestConnectionStateTimestamp:
         conn.last_user_message_at = now
         assert conn.last_user_message_at == now
 
+    def test_persona_id_defaults_to_yuri(self):
+        ws = MagicMock()
+        conn = ConnectionState(ws, uuid4())
+        assert conn.persona_id == "yuri"
+
 
 def _make_connection(idle_seconds: float = 400.0):
     conn = MagicMock()
@@ -30,6 +35,7 @@ def _make_connection(idle_seconds: float = 400.0):
     conn.last_user_message_at = time.time() - idle_seconds
     conn.connection_id = uuid4()
     conn.user_id = "test_user"
+    conn.persona_id = "yuri"
     conn.message_processor = MagicMock()
     conn.message_processor._current_turn_id = None
     return conn
@@ -138,3 +144,17 @@ class TestIdleWatcher:
         watcher.reset_connection(conn.connection_id)
         await watcher.scan_once()
         assert trigger_fn.call_count == 2
+
+    async def test_get_persona_fn_constructor_param(self):
+        conn = _make_connection(idle_seconds=200.0)
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+            persona_overrides={"yuri": 150},
+            get_persona_fn=lambda cid: "yuri",
+        )
+        await watcher.scan_once()
+        trigger_fn.assert_called_once()

--- a/tests/services/proactive_service/test_idle_watcher.py
+++ b/tests/services/proactive_service/test_idle_watcher.py
@@ -1,9 +1,11 @@
 """Tests for idle watcher and ConnectionState timestamp."""
 
 import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
+from src.services.proactive_service.config import ProactiveConfig
+from src.services.proactive_service.idle_watcher import IdleWatcher
 from src.services.websocket_service.manager.connection import ConnectionState
 
 
@@ -19,3 +21,120 @@ class TestConnectionStateTimestamp:
         now = time.time()
         conn.last_user_message_at = now
         assert conn.last_user_message_at == now
+
+
+def _make_connection(idle_seconds: float = 400.0):
+    conn = MagicMock()
+    conn.is_authenticated = True
+    conn.is_closing = False
+    conn.last_user_message_at = time.time() - idle_seconds
+    conn.connection_id = uuid4()
+    conn.user_id = "test_user"
+    conn.message_processor = MagicMock()
+    conn.message_processor._current_turn_id = None
+    return conn
+
+
+class TestIdleWatcher:
+    async def test_detects_idle_connection(self):
+        conn = _make_connection(idle_seconds=400.0)
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        trigger_fn.assert_called_once()
+
+    async def test_skips_active_connection(self):
+        conn = _make_connection(idle_seconds=10.0)
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        trigger_fn.assert_not_called()
+
+    async def test_skips_unauthenticated_connection(self):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.is_authenticated = False
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        trigger_fn.assert_not_called()
+
+    async def test_skips_closing_connection(self):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.is_closing = True
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        trigger_fn.assert_not_called()
+
+    async def test_skips_connection_with_active_turn(self):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.message_processor._current_turn_id = "active-turn"
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        trigger_fn.assert_not_called()
+
+    async def test_uses_persona_override_timeout(self):
+        conn = _make_connection(idle_seconds=200.0)
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+            persona_overrides={"yuri": 150},
+        )
+        await watcher.scan_once(get_persona_fn=lambda cid: "yuri")
+        trigger_fn.assert_called_once()
+
+    async def test_does_not_retrigger_same_connection(self):
+        conn = _make_connection(idle_seconds=400.0)
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        await watcher.scan_once()
+        trigger_fn.assert_called_once()  # only once despite two scans
+
+    async def test_reset_connection_allows_retrigger(self):
+        conn = _make_connection(idle_seconds=400.0)
+        trigger_fn = AsyncMock()
+        config = ProactiveConfig(idle_timeout_seconds=300, watcher_interval_seconds=1)
+        watcher = IdleWatcher(
+            config=config,
+            get_connections_fn=lambda: {conn.connection_id: conn},
+            trigger_fn=trigger_fn,
+        )
+        await watcher.scan_once()
+        watcher.reset_connection(conn.connection_id)
+        await watcher.scan_once()
+        assert trigger_fn.call_count == 2

--- a/tests/services/proactive_service/test_proactive_service.py
+++ b/tests/services/proactive_service/test_proactive_service.py
@@ -18,6 +18,7 @@ def _make_connection(idle_seconds: float = 400.0):
     conn.is_closing = False
     conn.last_user_message_at = time.time() - idle_seconds
     conn.user_id = "test_user"
+    conn.persona_id = "yuri"
     conn.message_processor = MagicMock()
     conn.message_processor._current_turn_id = None
     conn.websocket = AsyncMock()
@@ -192,6 +193,31 @@ class TestTriggerProactive:
             context="important event",
         )
         assert result["status"] == "triggered"
+
+    async def test_persona_id_from_connection(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.persona_id = "custom_persona"
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+
+        stream_kwargs: list[dict] = []
+
+        async def recording_stream(**kwargs):
+            stream_kwargs.append(kwargs)
+            yield {"type": "stream_start", "turn_id": "t1", "session_id": "s1"}
+            yield {
+                "type": "stream_end",
+                "turn_id": "t1",
+                "session_id": "s1",
+                "content": "",
+                "new_chats": [],
+            }
+
+        proactive_service._agent_service.stream = recording_stream
+
+        await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id, trigger_type="idle", idle_seconds=400
+        )
+        assert stream_kwargs[0]["persona_id"] == "custom_persona"
 
 
 class TestOnUserMessage:

--- a/tests/services/proactive_service/test_proactive_service.py
+++ b/tests/services/proactive_service/test_proactive_service.py
@@ -1,0 +1,209 @@
+"""Tests for ProactiveService — the main orchestrator."""
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.services.proactive_service.config import ProactiveConfig
+from src.services.proactive_service.proactive_service import ProactiveService
+
+
+def _make_connection(idle_seconds: float = 400.0):
+    conn = MagicMock()
+    conn.connection_id = uuid4()
+    conn.is_authenticated = True
+    conn.is_closing = False
+    conn.last_user_message_at = time.time() - idle_seconds
+    conn.user_id = "test_user"
+    conn.message_processor = MagicMock()
+    conn.message_processor._current_turn_id = None
+    conn.websocket = AsyncMock()
+    return conn
+
+
+@pytest.fixture
+def proactive_service(tmp_path):
+    prompts_file = tmp_path / "proactive_prompts.yml"
+    prompts_file.write_text(
+        "idle: |\n  유저가 {idle_seconds}초 동안 조용합니다.\n"
+        "webhook: |\n  컨텍스트: {context}\n"
+    )
+    config = ProactiveConfig(
+        idle_timeout_seconds=300,
+        cooldown_seconds=10,
+        watcher_interval_seconds=60,
+    )
+    ws_manager = MagicMock()
+    ws_manager.connections = {}
+    agent_service = AsyncMock()
+
+    async def mock_stream(**kwargs):
+        yield {"type": "stream_start", "turn_id": "t1", "session_id": "s1"}
+        yield {"type": "stream_token", "chunk": "Hello!"}
+        yield {
+            "type": "stream_end",
+            "turn_id": "t1",
+            "session_id": "s1",
+            "content": "Hello!",
+            "new_chats": [],
+        }
+
+    agent_service.stream = mock_stream
+    svc = ProactiveService(
+        config=config,
+        ws_manager=ws_manager,
+        agent_service=agent_service,
+        prompts_path=prompts_file,
+    )
+    return svc
+
+
+class TestTriggerProactive:
+    async def test_trigger_succeeds(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+            idle_seconds=400,
+        )
+        assert result["status"] == "triggered"
+        assert result["turn_id"] == "t1"
+
+    async def test_trigger_skipped_when_connection_not_found(self, proactive_service):
+        result = await proactive_service.trigger_proactive(
+            connection_id=uuid4(), trigger_type="idle"
+        )
+        assert result["status"] == "skipped"
+        assert "not found" in result["reason"]
+
+    async def test_trigger_skipped_when_connection_closing(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.is_closing = True
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id, trigger_type="idle"
+        )
+        assert result["status"] == "skipped"
+        assert "not found" in result["reason"]
+
+    async def test_cooldown_blocks_repeated_trigger(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result1 = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+            idle_seconds=400,
+        )
+        assert result1["status"] == "triggered"
+        result2 = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+            idle_seconds=400,
+        )
+        assert result2["status"] == "skipped"
+        assert "cooldown" in result2["reason"]
+
+    async def test_trigger_skipped_when_active_turn(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.message_processor._current_turn_id = "active-turn"
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+        )
+        assert result["status"] == "skipped"
+        assert "active turn" in result["reason"]
+
+    async def test_trigger_skipped_when_no_message_processor(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        conn.message_processor = None
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+        )
+        assert result["status"] == "skipped"
+        assert "active turn" in result["reason"]
+
+    async def test_idle_recheck_skips_if_became_active(self, proactive_service):
+        conn = _make_connection(idle_seconds=100.0)  # Less than 300s timeout
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+        )
+        assert result["status"] == "skipped"
+        assert "became active" in result["reason"]
+
+    async def test_non_idle_trigger_skips_idle_recheck(self, proactive_service):
+        """Non-idle triggers (e.g. scheduled) should not do idle recheck."""
+        conn = _make_connection(idle_seconds=100.0)  # Recently active
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="scheduled",
+            prompt_key="webhook",
+            context="test context",
+        )
+        assert result["status"] == "triggered"
+
+    async def test_proactive_flag_injected_in_events(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+            idle_seconds=400,
+        )
+        # Verify all events sent to websocket have proactive=True
+        for call_args in conn.websocket.send_text.call_args_list:
+            event = json.loads(call_args[0][0])
+            assert event.get("proactive") is True
+
+    async def test_trigger_handles_stream_error(self, proactive_service):
+        conn = _make_connection(idle_seconds=400.0)
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+
+        async def failing_stream(**kwargs):
+            raise RuntimeError("agent exploded")
+            yield
+
+        proactive_service._agent_service.stream = failing_stream
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="idle",
+            idle_seconds=400,
+        )
+        assert result["status"] == "skipped"
+        assert "error" in result["reason"]
+
+    async def test_prompt_key_override(self, proactive_service):
+        """When prompt_key is provided, it should be used instead of trigger_type."""
+        conn = _make_connection(idle_seconds=400.0)
+        proactive_service._ws_manager.connections = {conn.connection_id: conn}
+        result = await proactive_service.trigger_proactive(
+            connection_id=conn.connection_id,
+            trigger_type="scheduled",
+            prompt_key="webhook",
+            context="important event",
+        )
+        assert result["status"] == "triggered"
+
+
+class TestOnUserMessage:
+    def test_on_user_message_resets_idle_watcher(self, proactive_service):
+        cid = uuid4()
+        proactive_service._idle_watcher._triggered_connections.add(cid)
+        proactive_service.on_user_message(cid)
+        assert cid not in proactive_service._idle_watcher._triggered_connections
+
+
+class TestLifecycle:
+    async def test_start_stop(self, proactive_service):
+        await proactive_service.start()
+        assert proactive_service._idle_watcher._task is not None
+        await proactive_service.stop()

--- a/tests/services/proactive_service/test_prompt_loader.py
+++ b/tests/services/proactive_service/test_prompt_loader.py
@@ -1,0 +1,70 @@
+"""Tests for proactive prompt template loader."""
+
+import pytest
+
+from src.services.proactive_service.prompt_loader import PromptLoader
+
+
+@pytest.fixture
+def loader(tmp_path):
+    prompts_file = tmp_path / "proactive_prompts.yml"
+    prompts_file.write_text(
+        "idle: |\n"
+        "  유저가 {idle_seconds}초 동안 조용합니다.\n"
+        "  현재 시각은 {current_time}입니다.\n"
+        "webhook: |\n"
+        "  컨텍스트: {context}\n"
+    )
+    return PromptLoader(prompts_file)
+
+
+class TestPromptLoader:
+    def test_render_idle_prompt(self, loader):
+        """Idle prompt rendered with valid kwargs must contain interpolated values."""
+        result = loader.render("idle", idle_seconds=300, current_time="09:00:00")
+        assert "300" in result
+        assert "09:00:00" in result
+
+    def test_render_webhook_prompt(self, loader):
+        """Webhook prompt rendered with context kwarg must contain interpolated value."""
+        result = loader.render("webhook", context="서버 점검")
+        assert "서버 점검" in result
+
+    def test_missing_key_returns_fallback(self, loader):
+        """Rendering an unknown trigger type must return a fallback string containing the type name."""
+        result = loader.render("nonexistent")
+        assert "nonexistent" in result
+
+    def test_missing_variable_left_as_placeholder(self, loader):
+        """Rendering with a missing variable must leave the placeholder intact."""
+        # Render idle without current_time → {current_time} should stay
+        result = loader.render("idle", idle_seconds=300)
+        assert "{current_time}" in result
+
+    def test_reload(self, loader, tmp_path):
+        """After overwriting the YAML file and calling reload(), new templates are used."""
+        new_file = tmp_path / "proactive_prompts.yml"
+        new_file.write_text("custom: |\n  안녕 {name}!\n")
+        loader._path = new_file
+        loader.reload()
+
+        result = loader.render("custom", name="유리")
+        assert "유리" in result
+        # Old key should now be missing
+        fallback = loader.render("idle")
+        assert "idle" in fallback
+
+    def test_missing_file_results_in_empty_templates(self, tmp_path):
+        """PromptLoader with a non-existent file path must gracefully produce fallback renders."""
+        missing = tmp_path / "does_not_exist.yml"
+        loader = PromptLoader(missing)
+        result = loader.render("idle")
+        assert "idle" in result
+
+    def test_empty_yaml_results_in_fallback(self, tmp_path):
+        """An empty YAML file must result in fallback renders for all trigger types."""
+        empty_file = tmp_path / "empty.yml"
+        empty_file.write_text("")
+        loader = PromptLoader(empty_file)
+        result = loader.render("morning")
+        assert "morning" in result

--- a/tests/services/proactive_service/test_schedule_manager.py
+++ b/tests/services/proactive_service/test_schedule_manager.py
@@ -1,0 +1,74 @@
+"""Tests for ScheduleManager (APScheduler wrapper)."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from src.services.proactive_service.config import ProactiveConfig, ScheduleEntry
+from src.services.proactive_service.schedule_manager import ScheduleManager
+
+
+def _make_config(schedules=None):
+    return ProactiveConfig(schedules=schedules or [], watcher_interval_seconds=30)
+
+
+class TestScheduleManager:
+    async def test_start_registers_jobs(self):
+        config = _make_config(
+            schedules=[
+                ScheduleEntry(id="morning", cron="0 9 * * *", prompt_key="morning"),
+            ]
+        )
+        trigger_fn = AsyncMock()
+        get_connections_fn = MagicMock(return_value={})
+        mgr = ScheduleManager(
+            config=config, trigger_fn=trigger_fn, get_connections_fn=get_connections_fn
+        )
+        await mgr.start()
+        assert mgr.is_running()
+        await mgr.stop()
+
+    async def test_disabled_schedule_is_skipped(self):
+        config = _make_config(
+            schedules=[
+                ScheduleEntry(
+                    id="disabled", cron="0 9 * * *", prompt_key="x", enabled=False
+                ),
+            ]
+        )
+        trigger_fn = AsyncMock()
+        get_connections_fn = MagicMock(return_value={})
+        mgr = ScheduleManager(
+            config=config, trigger_fn=trigger_fn, get_connections_fn=get_connections_fn
+        )
+        await mgr.start()
+        jobs = mgr._scheduler.get_jobs()
+        assert len(jobs) == 0
+        await mgr.stop()
+
+    async def test_trigger_broadcasts_to_connections(self):
+        conn = MagicMock()
+        conn.connection_id = uuid4()
+        conn.is_authenticated = True
+        conn.is_closing = False
+        trigger_fn = AsyncMock()
+        config = _make_config()
+        get_connections_fn = MagicMock(return_value={conn.connection_id: conn})
+        mgr = ScheduleManager(
+            config=config, trigger_fn=trigger_fn, get_connections_fn=get_connections_fn
+        )
+        await mgr._on_schedule_fire(schedule_id="morning", prompt_key="morning")
+        trigger_fn.assert_called_once_with(
+            connection_id=conn.connection_id,
+            trigger_type="scheduled",
+            prompt_key="morning",
+        )
+
+    async def test_no_connections_is_noop(self):
+        trigger_fn = AsyncMock()
+        config = _make_config()
+        get_connections_fn = MagicMock(return_value={})
+        mgr = ScheduleManager(
+            config=config, trigger_fn=trigger_fn, get_connections_fn=get_connections_fn
+        )
+        await mgr._on_schedule_fire(schedule_id="morning", prompt_key="morning")
+        trigger_fn.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -154,6 +154,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -672,6 +684,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "apscheduler" },
     { name = "basedpyright" },
     { name = "cachetools" },
     { name = "ddgs" },
@@ -739,6 +752,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.0" },
+    { name = "apscheduler", specifier = ">=3.11.2" },
     { name = "basedpyright", specifier = ">=1.39.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.10.0" },
     { name = "cachetools", specifier = ">=5.5.0" },
@@ -4120,6 +4134,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/yaml_files/personas.yml
+++ b/yaml_files/personas.yml
@@ -1,6 +1,7 @@
 # yaml_files/personas.yml
 personas:
   yuri:
+    idle_timeout_seconds: 180
     system_prompt: |
       You are Yuri, a friendly but slightly mischievous 3D desktop AI companion.
       You assist your Master with various tasks and engage in witty conversation.

--- a/yaml_files/proactive_prompts.yml
+++ b/yaml_files/proactive_prompts.yml
@@ -1,0 +1,13 @@
+idle: |
+  유저가 {idle_seconds}초 동안 조용합니다.
+  현재 시각은 {current_time}입니다.
+  자연스럽게 말을 걸어주세요.
+
+morning: |
+  현재 시각은 {current_time}입니다.
+  아침 인사를 해주세요.
+
+webhook: |
+  외부 트리거가 발생했습니다.
+  컨텍스트: {context}
+  이 상황에 맞게 유저에게 알려주세요.

--- a/yaml_files/services.e2e.yml
+++ b/yaml_files/services.e2e.yml
@@ -127,3 +127,12 @@ summary_config:
   enabled: true
   turn_threshold: 20
   max_summary_length: 500
+
+# -----------------------------------------------------------------------------
+# Proactive Talking Service (E2E — short timeouts for fast testing)
+# -----------------------------------------------------------------------------
+proactive:
+  idle_timeout_seconds: 3
+  cooldown_seconds: 5
+  watcher_interval_seconds: 1
+  schedules: []

--- a/yaml_files/services.yml
+++ b/yaml_files/services.yml
@@ -126,3 +126,16 @@ summary_config:
   enabled: true
   turn_threshold: 20
   max_summary_length: 500
+
+# -----------------------------------------------------------------------------
+# Proactive Talking Service
+# -----------------------------------------------------------------------------
+proactive:
+  idle_timeout_seconds: 300
+  cooldown_seconds: 600
+  watcher_interval_seconds: 30
+  schedules:
+    - id: morning_greeting
+      cron: "0 9 * * *"
+      prompt_key: morning
+      enabled: true


### PR DESCRIPTION
## Summary

- **Phase 1 (Idle Timer)**: 유저가 N초 동안 입력 없으면 AI가 먼저 말을 걸음. `IdleWatcher`가 주기적으로 connection을 스캔하고, 페르소나별 timeout 오버라이드 지원.
- **Phase 2 (Scheduled Trigger)**: APScheduler 기반 시간 트리거 — YAML에 cron 스케줄 정의하면 해당 시각에 모든 활성 세션에 발화.
- **Phase 3 (Webhook Trigger)**: `POST /v1/proactive/trigger` endpoint — 외부에서 특정 세션에 proactive 발화를 트리거.
- **공통**: 단일 `ProactiveService` 오케스트레이터가 3가지 트리거를 관리. Lock 체크 + idle 재확인 + 쿨다운으로 충돌 방지. YAML 프롬프트 템플릿, `proactive: true` WS 이벤트 태깅.

## New Files
- `src/services/proactive_service/` — config, prompt_loader, idle_watcher, schedule_manager, proactive_service
- `src/api/routes/proactive.py`, `src/models/proactive.py`
- `yaml_files/proactive_prompts.yml`
- Unit tests (50+) + E2E tests (2)

## Test Plan
- [x] Unit tests: 692 passed, 0 failed
- [x] Lint: black + ruff + 23 structural tests clean
- [x] E2E: `make e2e` — 28 passed (proactive webhook + idle 2건 포함)
- [x] App log errors: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)