### PR TITLE
chore: update data_flow docs and Docker/YAML config (HitL, proactive, KI-23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.13-slim
 COPY --from=ghcr.io/astral-sh/uv:0.9.5 /uv /uvx /usr/local/bin/
 
 # Create non-root user before any file operations
-RUN adduser --disabled-password --gecos '' appuser
+RUN adduser --disabled-password --gecos '' --uid 1002 appuser
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build: .
     volumes:
       - ./resources:/app/resources
+      - ./src:/app/src
+      - ./yaml_files:/app/yaml_files
+      - ./logs:/app/logs
     ports:
       - "5500:5500"
     env_file:

--- a/docs/data_flow/agent/HITL_GATE_FLOW.md
+++ b/docs/data_flow/agent/HITL_GATE_FLOW.md
@@ -118,7 +118,7 @@ sequenceDiagram
     end
 ```
 
-## 3. Usage
+## 4. Usage
 
 ### FE → hitl_response 메시지 형식
 
@@ -159,10 +159,10 @@ sequenceDiagram
 ### B. Middleware Chain Order
 
 ```
-ToolGate → Delegate → LTM → Profile → Summary → TaskStatus → HitL
+ToolGate → HitL → Delegate → Profile → Summary → LTM → TaskStatus
 ```
 
-HitL은 chain 마지막에 위치 — 모든 다른 middleware가 tool call 전에 실행된 후 최종 게이트로 동작.
+HitL은 ToolGate 바로 다음(2번째)에 위치 — 위험 도구 호출을 조기에 차단하여 불필요한 downstream middleware 실행을 방지.
 
 ### C. 제약 사항
 

--- a/docs/data_flow/agent/HITL_GATE_FLOW.md
+++ b/docs/data_flow/agent/HITL_GATE_FLOW.md
@@ -1,0 +1,175 @@
+# HitL Gate Data Flow
+
+Updated: 2026-04-15
+
+## 1. Synopsis
+
+- **Purpose**: 위험 도구(MCP 도구, `delegate_task`) 호출 시 사용자 승인 게이트를 거쳐 실행 여부를 결정하는 흐름
+- **I/O**: Agent tool call → `interrupt()` → FE 승인 UI → `hitl_response` → 도구 실행 또는 거부
+
+## 2. Core Logic
+
+### 2-1. 도구 분류
+
+| 분류 | 도구 | HitL 필요 |
+|------|------|:---:|
+| **Safe** | `search_memory`, `update_user_profile` 등 빌트인 도구 | ❌ |
+| **Dangerous** | 모든 MCP 도구 (동적, init 시 등록) | ✅ |
+| **Dangerous** | `delegate_task` (NanoClaw 위임) | ✅ |
+| **Dangerous** | Static deny-list 도구 (Phase 1: 비어있음) | ✅ |
+
+분류 로직: `HitLMiddleware.is_dangerous(tool_name)` — MCP 도구 이름 + `delegate_task` + deny-list를 합친 frozenset으로 판단.
+
+### 2-2. HitL 요청 흐름
+
+```
+Agent tool call (dangerous)
+  → HitLMiddleware.awrap_tool_call()
+    → interrupt({tool_name, tool_args, request_id})
+      → GraphInterrupt 예외 발생 (LangGraph runtime가 catch)
+      → Graph suspended at checkpoint
+  → event_handlers: hitl_request 이벤트 감지
+    → TurnStatus.AWAITING_APPROVAL 설정
+    → hitl_request → event_queue → FE 전달
+    → token_queue에 SENTINEL 전송
+    → Producer exit (return) — graph 재개 대기
+```
+
+### 2-3. FE 승인 → 재개 흐름
+
+```
+FE: hitl_request 수신 (tool_name, tool_args, request_id)
+  → 승인 UI 표시 (사용자에게 "이 도구 실행을 허용하시겠습니까?")
+  → 사용자 응답:
+    ├─ 승인: hitl_response (request_id, approved=true)
+    │   → handlers.handle_hitl_response()
+    │     → TurnStatus.PROCESSING 변경
+    │     → agent_service.resume_after_approval(session_id, approved, request_id)
+    │     → Command(resume={approved: true}) → graph 재개
+    │     → processor.attach_agent_stream(turn_id, agent_stream)
+    │     → forward_events 재시작 → stream_start → stream_token → ...
+    │
+    └─ 거부: hitl_response (request_id, approved=false)
+        → resume_value={approved: false}
+        → HitLMiddleware: "사용자가 '{tool_name}' 도구 실행을 거부했습니다." 반환
+        → Agent가 대체 방법 시도 → 정상 stream_end
+```
+
+### 2-4. 가드 조건
+
+`handle_hitl_response()` 진입 시 검증:
+
+1. Connection 존재 + message_processor 있음
+2. Active turn 존재 (_current_turn_id not None)
+3. Turn 상태가 `AWAITING_APPROVAL` 임
+4. AgentService 사용 가능
+
+실패 시 `ErrorMessage` (code 4004) 반환.
+
+## 3. 전체 시퀀스
+
+```mermaid
+sequenceDiagram
+    participant FE as Client (FE)
+    participant WS as WebSocket Handler
+    participant MP as MessageProcessor
+    participant EH as EventHandler
+    participant Agent as LangGraph Agent
+    participant HitL as HitLMiddleware
+    participant Tool as Target Tool
+
+    Note over FE, Tool: Phase 1: HitL Request
+    Agent->>HitL: awrap_tool_call(dangerous_tool)
+    HitL->>HitL: interrupt({tool_name, args, request_id})
+    HitL-->>Agent: GraphInterrupt (suspend)
+    Agent-->>EH: hitl_request event
+    EH->>MP: update_turn_status(AWAITING_APPROVAL)
+    EH->>MP: _put_event(hitl_request)
+    EH->>EH: signal_token_stream_closed
+    EH->>EH: wait_for_token_queue
+    EH-->>EH: return (producer exit)
+    MP-->>WS: hitl_request via event_queue
+    WS-->>FE: hitl_request (tool_name, tool_args, request_id)
+
+    Note over FE, Tool: Phase 2: FE Approval UI
+    FE->>FE: Show approval dialog to user
+    opt User approves
+        FE->>WS: hitl_response (request_id, approved=true)
+        WS->>WS: handle_hitl_response()
+        WS->>MP: update_turn_status(PROCESSING)
+        WS->>Agent: resume_after_approval(session_id, approved, request_id)
+        Agent->>HitL: Command(resume={approved: true})
+        HitL->>Tool: handler(request) — execute tool
+        Tool-->>Agent: tool result
+        Agent-->>EH: stream_token / stream_end (resume)
+        EH->>MP: _put_event(stream_token)
+        MP-->>WS: event_queue → client
+        WS-->>FE: stream_token / stream_end
+    else User denies
+        FE->>WS: hitl_response (request_id, approved=false)
+        WS->>WS: handle_hitl_response()
+        WS->>Agent: resume_after_approval(session_id, approved=false)
+        Agent->>HitL: Command(resume={approved: false})
+        HitL-->>Agent: "사용자가 도구 실행을 거부했습니다."
+        Agent-->>EH: stream_token (denial message) → stream_end
+        EH->>MP: _put_event(stream_token)
+        MP-->>WS: event_queue → client
+        WS-->>FE: stream_token / stream_end
+    end
+```
+
+## 3. Usage
+
+### FE → hitl_response 메시지 형식
+
+```json
+{
+  "type": "hitl_response",
+  "request_id": "uuid-from-hitl_request",
+  "approved": true
+}
+```
+
+### hitl_request 메시지 형식 (FE 수신)
+
+```json
+{
+  "type": "hitl_request",
+  "tool_name": "delegate_task",
+  "tool_args": { "task": "..." },
+  "request_id": "uuid",
+  "turn_id": "uuid"
+}
+```
+
+---
+
+## Appendix
+
+### A. 주요 구현 파일
+
+| 파일 | 역할 |
+|------|------|
+| `src/services/agent_service/middleware/hitl_middleware.py` | HitLMiddleware — interrupt() + resume_value 처리 |
+| `src/services/agent_service/openai_chat_agent.py` | resume_after_approval() — Command(resume=...) 생성 |
+| `src/services/websocket_service/message_processor/event_handlers.py` | hitl_request 이벤트 처리, producer exit |
+| `src/services/websocket_service/message_processor/models.py` | TurnStatus.AWAITING_APPROVAL |
+| `src/services/websocket_service/manager/handlers.py` | handle_hitl_response() — FE 응답 라우팅 |
+
+### B. Middleware Chain Order
+
+```
+ToolGate → Delegate → LTM → Profile → Summary → TaskStatus → HitL
+```
+
+HitL은 chain 마지막에 위치 — 모든 다른 middleware가 tool call 전에 실행된 후 최종 게이트로 동작.
+
+### C. 제약 사항
+
+- **LangGraph checkpoint 필요**: `interrupt()`는 LangGraph의 checkpoint 기능이 활성화된 상태에서만 동작
+- **단일 HitL per turn**: 동시 다중 HitL 요청은 지원하지 않음 (Phase 1 MVP 제한)
+- **Timeout 없음**: FE가 응답하지 않으면 graph는 indefinitely suspended 상태 (FE reconnect 시 재시도 필요)
+
+### D. PatchNote
+
+2026-04-15: 최초 작성. PR #36 (feat: Human-in-the-Loop approval gate) 기반.

--- a/docs/data_flow/chat/ADD_CHAT_MESSAGE.md
+++ b/docs/data_flow/chat/ADD_CHAT_MESSAGE.md
@@ -56,6 +56,18 @@ sequenceDiagram
             FE-->>User: Play VRM Motion & Expression
         end
 
+        alt HitL Gate Trigger (위험 도구 호출 시)
+            Note right of BE: MCP 도구 또는 delegate_task 호출 시<br/>HitLMiddleware가 interrupt() 발생
+            BE-->>FE: hitl_request (tool_name, tool_args, request_id)
+            BE->>BE: TurnStatus → AWAITING_APPROVAL<br/>Producer exit (graph suspended at checkpoint)
+            FE->>FE: 승인 UI 표시 (사용자에게 도구 실행 확인)
+            FE->>BE: hitl_response (request_id, approved=true/false)
+            BE->>BE: TurnStatus → PROCESSING
+            BE->>BE: agent_service.resume_after_approval()
+            BE-->>FE: stream_start (재개)
+            BE-->>FE: stream_token / tts_chunk (계속)
+        end
+
         BE->>STM: save_turn(user+assistant messages)<br/>(asyncio.create_task — non-blocking)
         BE-->>FE: stream_end (session_id, content)
         Note right of FE: Guaranteed: all tts_chunk events arrive before stream_end
@@ -114,7 +126,16 @@ sequenceDiagram
 - Frontend does not directly call STM APIs for saving; it only reads history when loading sessions.
 - Session persistence is guaranteed by the backend's `stream_end` logic.
 
+### HitL Gate
+
+- **Trigger**: MCP 도구 또는 `delegate_task` 호출 시 `HitLMiddleware.awrap_tool_call()`이 `interrupt()` 발생
+- **Safe tools**: `search_memory`, `update_user_profile` 등 — HitL 없이 즉시 실행
+- **Dangerous tools**: 모든 MCP 도구 + `delegate_task` + static deny-list
+- **Resume**: FE에서 `hitl_response` 전송 → `agent_service.resume_after_approval()` → graph 재개
+- **Denial**: 거부 시 `"사용자가 '{tool_name}' 도구 실행을 거부했습니다."` 메시지 반환
+
 ## Appendix
 
 - [Backend WebSocket API](../../websocket/WEBSOCKET_API_GUIDE.md)
 - [TTS Chunk Event](../../websocket/WebSocket_TtsChunk.md)
+- [HitL Gate Flow](../../data_flow/agent/HITL_GATE_FLOW.md)

--- a/docs/data_flow/chat/CONTEXT_INJECTION_FLOW.md
+++ b/docs/data_flow/chat/CONTEXT_INJECTION_FLOW.md
@@ -61,6 +61,14 @@ sequenceDiagram
 | **요약 주입 구분자** | `\n\nPrevious Conversation Summary:` | `src/services/agent_service/middleware/summary_middleware.py` 내 `_SUMMARY_SECTION_HEADER` | SystemMessage 내에서 요약본을 찾아 치환할 때 사용하는 고정 문자열. **임의 변경 시 치환 버그 발생 주의** |
 | **프로필 주입 구분자** | `\n\nUser Profile:` | `src/services/agent_service/middleware/profile_middleware.py` 내 `_PROFILE_SECTION_HEADER` | SystemMessage 내에서 프로필을 찾아 치환할 때 사용하는 고정 문자열. |
 
+### Middleware Chain Order
+
+```
+ToolGate → Delegate → LTM → Profile → Summary → TaskStatus → HitL
+```
+
+- **HitLMiddleware** (PR #36): chain 마지막 위치. MCP 도구 + `delegate_task` 호출 시 `interrupt()`로 FE 승인 게이트. Safe 도구(`search_memory`, `update_user_profile`)는 통과.
+
 ### 2-2. 제약 및 주의 사항 (Constraints)
 
 - **문자열 치환 기반 주입**: Pre-hook은 `SystemMessage` 내에서 `_SUMMARY_SECTION_HEADER`와 `_PROFILE_SECTION_HEADER`를 `.split()`으로 찾아 텍스트를 통째로 교체합니다. **이 구분자 문자열을 함부로 수정하면 중복 주입되거나 주입이 누락되는 치명적 버그가 발생합니다.**

--- a/docs/data_flow/chat/CONTEXT_INJECTION_FLOW.md
+++ b/docs/data_flow/chat/CONTEXT_INJECTION_FLOW.md
@@ -64,10 +64,10 @@ sequenceDiagram
 ### Middleware Chain Order
 
 ```
-ToolGate → Delegate → LTM → Profile → Summary → TaskStatus → HitL
+ToolGate → HitL → Delegate → Profile → Summary → LTM → TaskStatus
 ```
 
-- **HitLMiddleware** (PR #36): chain 마지막 위치. MCP 도구 + `delegate_task` 호출 시 `interrupt()`로 FE 승인 게이트. Safe 도구(`search_memory`, `update_user_profile`)는 통과.
+- **HitLMiddleware** (PR #36): ToolGate 다음 2번째 위치. MCP 도구 + `delegate_task` 호출 시 `interrupt()`로 FE 승인 게이트. Safe 도구(`search_memory`, `update_user_profile`)는 통과.
 
 ### 2-2. 제약 및 주의 사항 (Constraints)
 

--- a/docs/data_flow/chat/STREAM_TOKEN_TTS_FLOW.md
+++ b/docs/data_flow/chat/STREAM_TOKEN_TTS_FLOW.md
@@ -37,14 +37,18 @@ agent_service.stream()
 ```
 producer(agent_stream):
   stream_token event
-    ├─ token_queue.put(event)    # consumer가 TTS 처리에 사용
-    └─ event_queue.put(event)    # client에 즉시 전달
+    ├─ token_queue.put(event)           # consumer가 TTS 처리에 사용 (원본 chunk, 이모지 포함)
+    └─ event_queue.put(fe_event)        # client에 전달 (chunk에서 emotion emoji 제거됨)
 ```
+
+**KI-23**: Unity FE가 emotion emoji(😊, 😭 등)를 렌더링하지 못해 `strip_emotion_tags()`로 FE 전달 전 chunk에서 제거. TTS 파이프라인은 원본 chunk를 받아 emotion detection에 사용.
 
 `stream_token` 이벤트 schema:
 ```json
 { "type": "stream_token", "chunk": "str", "turn_id": "uuid", "node": "str|null" }
 ```
+- FE 전달 시: `chunk`에서 emotion emoji 제거 (`strip_emotion_tags`)
+- TTS 전달 시: `chunk` 원본 유지 (emotion detection용)
 
 ### 2-3. tts_chunk 생성 흐름
 
@@ -89,8 +93,9 @@ producer: stream_end 수신
 
 `stream_end` 이벤트 schema:
 ```json
-{ "type": "stream_end", "session_id": "uuid", "content": "전체 응답 텍스트" }
+{ "type": "stream_end", "session_id": "uuid", "content": "전체 응답 텍스트 (emotion emoji 제거됨)" }
 ```
+- `content` 필드에도 `strip_emotion_tags()` 적용 (KI-23). TTS 파이프라인은 이미 원본을 처리 완료한 시점.
 
 ## 3. 전체 시퀀스
 
@@ -114,9 +119,9 @@ sequenceDiagram
     FWD-->>Client: stream_start
 
     loop 토큰 스트리밍
-        Agent-->>Prod: stream_token(chunk)
-        Prod->>Cons: token_queue ← stream_token
-        Prod->>FWD: event_queue ← stream_token
+        Agent-->>Prod: stream_token(chunk_with_emoji)
+        Prod->>Cons: token_queue ← stream_token (원본, 이모지 포함)
+        Prod->>FWD: event_queue ← stream_token (chunk에서 이모지 제거)
         FWD-->>Client: stream_token
 
         Cons->>Cons: 문장 완성 감지
@@ -156,4 +161,5 @@ sequenceDiagram
 
 ### C. PatchNote
 
+2026-04-15: KI-23 반영 — `stream_token`/`stream_end`의 `chunk`/`content`에서 emotion emoji 제거 (`strip_emotion_tags`). TTS 파이프라인은 원본 유지.
 2026-04-08: 최초 작성. stream_token + tts_chunk 파이프라인 코드베이스 추적 기반.

--- a/docs/data_flow/proactive/PROACTIVE_TRIGGER_FLOW.md
+++ b/docs/data_flow/proactive/PROACTIVE_TRIGGER_FLOW.md
@@ -1,0 +1,153 @@
+# Proactive Trigger Data Flow
+
+Updated: 2026-04-15
+
+## 1. Synopsis
+
+- **Purpose**: 3가지 트리거 경로(`idle`, `schedule`, `webhook`)가 `ProactiveService.trigger_proactive()`를 거쳐 agent 응답을 WebSocket으로 직접 전송하는 흐름
+- **I/O**: Idle watcher / Cron schedule / POST `/v1/proactive/trigger` → `stream_start` · `stream_token` · `tts_chunk` · `stream_end` → Client WS
+
+## 2. Core Logic
+
+### 2-1. 트리거 경로
+
+| 경로 | 진입점 | trigger_type | prompt_key |
+|------|--------|-------------|------------|
+| **Idle Watcher** | `IdleWatcher.scan_once()` | `"idle"` | `"idle"` (기본) |
+| **Schedule Manager** | `ScheduleManager._on_schedule_fire()` | `"scheduled"` | YAML에서 명시 |
+| **Webhook** | `POST /v1/proactive/trigger` | 요청 body | 요청 body (선택) |
+
+### 2-2. 공통 가드 (trigger_proactive)
+
+모든 트리거는 동일 검증 파이프라인을 통과:
+
+```
+1. Connection 존재 + closing 아님
+2. Active turn 없음 (_current_turn_id is None)
+3. Idle 재확인 (idle 트리거만) — last_user_message_at < timeout
+4. Cooldown — last_proactive_at + cooldown_seconds 경과
+```
+
+가드 통과 실패 시 `{"status": "skipped", "reason": "..."}` 반환.
+
+### 2-3. Prompt → Agent → WS
+
+```
+trigger_proactive():
+  PromptLoader.render(key, idle_seconds, current_time, context)
+    └─ proactive_prompts.yml에서 템플릿 로드 + 변수 치환
+  AgentService.stream([SystemMessage(prompt_text)])
+    └─ session_id=connection_id, persona_id=conn.persona_id, agent_id="proactive"
+  for event in agent_stream:
+    event["proactive"] = True          # FE가 proactive 메시지 식별용
+    websocket.send_text(json.dumps(event))
+  last_proactive_at[connection_id] = now
+```
+
+**중요**: 일반 chat turn과 달리 `MessageProcessor`를 거치지 않음. Agent stream을 직접 WS로 전송하므로 `event_handlers.py` 파이프라인(tts_chunk 생성, token_queue, event_queue)이 **개입하지 않는다**. TTS chunk는 agent_service 내부에서 생성되어 그대로 전달됨.
+
+### 2-4. Idle Watcher 동작
+
+```
+IdleWatcher._loop():
+  every watcher_interval_seconds (기본 30s):
+    scan_once():
+      for each authenticated connection:
+        idle_seconds = now - conn.last_user_message_at
+        if idle_seconds >= idle_timeout_seconds (기본 300s):
+          if connection not in triggered_connections:
+            triggered_connections.add(connection_id)
+            trigger_fn(connection_id, trigger_type="idle", idle_seconds=N)
+```
+
+- `triggered_connections` set: 동일 connection 중복 트리거 방지
+- `reset_connection()`: 유저 메시지 발생 시 호출되어 triggered set에서 제거
+- `persona_overrides`: per-persona idle_timeout 적용 (예: yuri=3s for E2E)
+
+## 3. 전체 시퀀스
+
+```mermaid
+sequenceDiagram
+    participant Trigger as Idle/Schedule/Webhook
+    participant PS as ProactiveService
+    participant Guard as 가드 검증
+    participant PL as PromptLoader
+    participant Agent as AgentService
+    participant WS as Client WebSocket
+
+    Trigger->>PS: trigger_proactive(conn_id, type, key)
+    PS->>Guard: connection / turn / idle / cooldown
+    alt 가드 실패
+        Guard-->>PS: skipped (reason)
+        PS-->>Trigger: {"status": "skipped"}
+    else 가드 통과
+        PS->>PL: render(key, idle_seconds, time, context)
+        PL-->>PS: prompt_text
+        PS->>Agent: stream([SystemMessage(prompt)])
+        Agent-->>PS: stream_start (proactive=true)
+        PS->>WS: send(stream_start)
+        Agent-->>PS: stream_token (proactive=true)
+        PS->>WS: send(stream_token)
+        Agent-->>PS: tts_chunk (proactive=true)
+        PS->>WS: send(tts_chunk)
+        Agent-->>PS: stream_end (proactive=true)
+        PS->>WS: send(stream_end)
+        PS->>PS: last_proactive_at[conn_id] = now
+    end
+```
+
+## 3. Usage
+
+### Webhook Trigger
+
+```bash
+curl -X POST http://localhost:5500/v1/proactive/trigger \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "<uuid>", "trigger_type": "manual", "prompt_key": "greeting"}'
+```
+
+### YAML Config
+
+```yaml
+# yaml_files/services.yml
+proactive:
+  idle_timeout_seconds: 300
+  cooldown_seconds: 600
+  watcher_interval_seconds: 30
+  persona_overrides:
+    yuri: 300
+  schedules:
+    - id: morning_greeting
+      cron: "0 9 * * 1-5"
+      prompt_key: morning
+      enabled: true
+```
+
+---
+
+## Appendix
+
+### A. 주요 구현 파일
+
+| 파일 | 역할 |
+|------|------|
+| `src/services/proactive_service/proactive_service.py` | orchestrator, trigger_proactive |
+| `src/services/proactive_service/idle_watcher.py` | periodic idle scan |
+| `src/services/proactive_service/schedule_manager.py` | APScheduler cron jobs |
+| `src/services/proactive_service/prompt_loader.py` | proactive_prompts.yml 템플릿 |
+| `src/services/proactive_service/config.py` | ProactiveConfig, ScheduleEntry |
+| `src/api/routes/proactive.py` | POST /v1/proactive/trigger |
+
+### B. 일반 Chat vs Proactive 차이
+
+| | 일반 Chat | Proactive |
+|--|----------|-----------|
+| 진입점 | WS `chat_message` | Idle/Schedule/Webhook |
+| MessageProcessor | 사용 (event_handlers 파이프라인) | **사용 안 함** |
+| TTS chunk 생성 | `event_handlers.py` (TextChunkProcessor → TTSTextProcessor) | AgentService 내부 |
+| event["proactive"] | False | True |
+| session_id | 사용자 지정 | connection_id |
+
+### C. PatchNote
+
+2026-04-15: 최초 작성. PR #38 (feat/proactive-talking) 기반.

--- a/docs/data_flow/proactive/PROACTIVE_TRIGGER_FLOW.md
+++ b/docs/data_flow/proactive/PROACTIVE_TRIGGER_FLOW.md
@@ -96,7 +96,7 @@ sequenceDiagram
     end
 ```
 
-## 3. Usage
+## 4. Usage
 
 ### Webhook Trigger
 

--- a/yaml_files/services.docker.yml
+++ b/yaml_files/services.docker.yml
@@ -127,3 +127,16 @@ summary_config:
   enabled: true
   turn_threshold: 20
   max_summary_length: 500
+
+# -----------------------------------------------------------------------------
+# Proactive Talking Service
+# -----------------------------------------------------------------------------
+proactive:
+  idle_timeout_seconds: 300
+  cooldown_seconds: 600
+  watcher_interval_seconds: 30
+  schedules:
+    - id: morning_greeting
+      cron: "0 9 * * *"
+      prompt_key: morning
+      enabled: false


### PR DESCRIPTION
## Summary

- **New**: `docs/data_flow/agent/HITL_GATE_FLOW.md` — Full HitL approval gate flow (interrupt → FE approval → graph resume/deny)
- **New**: `docs/data_flow/proactive/PROACTIVE_TRIGGER_FLOW.md` — 3 trigger paths (idle watcher, cron schedule, webhook) → agent → direct WS
- **Update**: `STREAM_TOKEN_TTS_FLOW.md` — KI-23: `strip_emotion_tags` on stream_token chunk and stream_end content before FE forwarding
- **Update**: `ADD_CHAT_MESSAGE.md` — Add HitL branch to sequence diagram
- **Update**: `CONTEXT_INJECTION_FLOW.md` — Add HitL to middleware chain order
- **Docker**: UID 1002 fix, dev volume mounts (src/yaml_files/logs)
- **Config**: `services.docker.yml` — Add proactive service config

## Related PRs

Reflects changes from merged PRs: #36 (HitL), #38 (proactive), #39 (KI-23)