### PR TITLE
Feature/backend viseme pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "langchain-community>=0.4.1",
     "ddgs>=9.13.0",
     "apscheduler>=3.11.2",
+    "pyopenjtalk-plus>=0.4.1",
 ]
 
 [project.optional-dependencies]

--- a/src/main.py
+++ b/src/main.py
@@ -97,6 +97,7 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
                 initialize_mongodb_client,
                 initialize_tts_service,
                 initialize_user_profile_service,
+                initialize_viseme_mapper,
             )
 
             svc_config = config_paths.get("services_config_path")
@@ -105,6 +106,8 @@ def create_app(config_paths: dict | None = None) -> FastAPI:
             initialize_tts_service(config_path=svc_config)
 
             initialize_emotion_motion_mapper()
+
+            initialize_viseme_mapper()
 
             # MongoDB client for checkpointer + session_registry (before agent)
             initialize_mongodb_client(config_path=svc_config)

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -12,6 +12,7 @@ from src.services.service_manager import (
     get_summary_service,
     get_tts_service,
     get_user_profile_service,
+    get_viseme_mapper,
     initialize_agent_service,
     initialize_channel_service,
     initialize_emotion_motion_mapper,
@@ -22,6 +23,7 @@ from src.services.service_manager import (
     initialize_sweep_service,
     initialize_tts_service,
     initialize_user_profile_service,
+    initialize_viseme_mapper,
 )
 
 __all__ = [
@@ -36,6 +38,7 @@ __all__ = [
     "get_summary_service",
     "get_tts_service",
     "get_user_profile_service",
+    "get_viseme_mapper",
     "health_service",
     "initialize_agent_service",
     "initialize_channel_service",
@@ -47,4 +50,5 @@ __all__ = [
     "initialize_sweep_service",
     "initialize_tts_service",
     "initialize_user_profile_service",
+    "initialize_viseme_mapper",
 ]

--- a/src/services/service_manager.py
+++ b/src/services/service_manager.py
@@ -32,6 +32,7 @@ from src.services.pending_task_repository import PendingTaskRepository
 from src.services.summary_service import SummaryService
 from src.services.tts_service import TTSFactory, TTSService
 from src.services.tts_service.emotion_motion_mapper import EmotionMotionMapper
+from src.services.tts_service.viseme_mapper import VisemeMapper
 from src.services.user_profile_service import UserProfileService
 
 # Global service instances
@@ -39,6 +40,7 @@ _tts_service_instance: TTSService | None = None
 _agent_service_instance: AgentService | None = None
 _ltm_service_instance: LTMService | None = None
 _emotion_motion_mapper_instance: EmotionMotionMapper | None = None
+_viseme_mapper_instance: VisemeMapper | None = None
 _mongo_client: "_pymongo.MongoClient | None" = None
 _mongo_db: "_pymongo.database.Database | None" = None
 _session_registry_instance: "SessionRegistry | None" = None
@@ -531,6 +533,30 @@ def get_emotion_motion_mapper() -> EmotionMotionMapper | None:
     return _emotion_motion_mapper_instance
 
 
+def initialize_viseme_mapper(
+    force_reinit: bool = False,
+) -> VisemeMapper:
+    """Initialize VisemeMapper singleton.
+
+    Returns:
+        Initialized VisemeMapper instance
+    """
+    global _viseme_mapper_instance
+
+    if _viseme_mapper_instance is not None and not force_reinit:
+        logger.debug("VisemeMapper already initialized, skipping")
+        return _viseme_mapper_instance
+
+    _viseme_mapper_instance = VisemeMapper()
+    logger.info("VisemeMapper initialized")
+    return _viseme_mapper_instance
+
+
+def get_viseme_mapper() -> VisemeMapper | None:
+    """Get the initialized VisemeMapper instance."""
+    return _viseme_mapper_instance
+
+
 def _load_service_yaml(
     service_name: str,
     default_config_path: Path,
@@ -711,6 +737,7 @@ __all__ = [
     "get_summary_service",
     "get_tts_service",
     "get_user_profile_service",
+    "get_viseme_mapper",
     "initialize_agent_service",
     "initialize_channel_service",
     "initialize_emotion_motion_mapper",
@@ -722,5 +749,6 @@ __all__ = [
     "initialize_sweep_service",
     "initialize_tts_service",
     "initialize_user_profile_service",
+    "initialize_viseme_mapper",
     "reset_mongo_client",
 ]

--- a/src/services/tts_service/tts_pipeline.py
+++ b/src/services/tts_service/tts_pipeline.py
@@ -3,12 +3,38 @@
 synthesize_chunk() never raises. All errors are logged to backend only.
 """
 
+import base64
+import struct
 from asyncio import to_thread
 
 from src.core.logger import logger
 from src.models.websocket import TimelineKeyframe, TtsChunkMessage
 from src.services.tts_service.emotion_motion_mapper import EmotionMotionMapper
 from src.services.tts_service.service import TTSService
+
+
+def wav_duration(data: bytes | None) -> float:
+    """Calculate duration in seconds from raw WAV bytes.
+
+    Returns 0.0 on invalid input or parse failure.
+    """
+    if not data or len(data) < 44:
+        return 0.0
+    try:
+        if data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+            return 0.0
+        # Parse fmt chunk: channels at offset 22, sample_rate at 24, bits at 34
+        channels = struct.unpack_from("<H", data, 22)[0]
+        sample_rate = struct.unpack_from("<I", data, 24)[0]
+        bits_per_sample = struct.unpack_from("<H", data, 34)[0]
+        if sample_rate == 0 or channels == 0 or bits_per_sample == 0:
+            return 0.0
+        # Find data chunk size at offset 40
+        data_size = struct.unpack_from("<I", data, 40)[0]
+        bytes_per_sample = bits_per_sample // 8
+        return data_size / (sample_rate * channels * bytes_per_sample)
+    except (struct.error, ZeroDivisionError):
+        return 0.0
 
 
 async def synthesize_chunk(

--- a/src/services/tts_service/tts_pipeline.py
+++ b/src/services/tts_service/tts_pipeline.py
@@ -98,11 +98,21 @@ async def synthesize_chunk(
                         if isinstance(targets_value, dict):
                             emotion_targets = targets_value
 
-                viseme_keyframes = viseme_mapper.generate(
-                    text, duration, emotion_targets
-                )
+                try:
+                    viseme_keyframes = viseme_mapper.generate(
+                        text, duration, emotion_targets
+                    )
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "[Viseme] generate failed, falling back to emotion keyframes"
+                    )
+                    viseme_keyframes = []
                 if viseme_keyframes:
                     keyframes = viseme_keyframes
+    else:
+        logger.warning(
+            f"[TTS] generate_speech returned no audio for sequence {sequence}"
+        )
 
     return TtsChunkMessage(
         sequence=sequence,

--- a/src/services/tts_service/tts_pipeline.py
+++ b/src/services/tts_service/tts_pipeline.py
@@ -11,6 +11,7 @@ from src.core.logger import logger
 from src.models.websocket import TimelineKeyframe, TtsChunkMessage
 from src.services.tts_service.emotion_motion_mapper import EmotionMotionMapper
 from src.services.tts_service.service import TTSService
+from src.services.tts_service.viseme_mapper import VisemeMapper
 
 
 def wav_duration(data: bytes | None) -> float:
@@ -45,53 +46,68 @@ async def synthesize_chunk(
     sequence: int,
     tts_enabled: bool = True,
     reference_id: str | None = None,
+    viseme_mapper: VisemeMapper | None = None,
 ) -> TtsChunkMessage:
+    """Synthesize a text chunk into audio + animation keyframes.
+
+    Always returns a TtsChunkMessage, never raises.
+    When viseme_mapper is provided and TTS succeeds, generates lip-sync
+    keyframes merged with emotion targets. Falls back to emotion-only
+    keyframes on any failure.
     """
-    Always returns a single TtsChunkMessage.
-
-    Behavior:
-    - tts_enabled=True: calls generate_speech() via asyncio.to_thread()
-    - tts_enabled=False: skips TTS API, audio_base64=None (normal state)
-    - On failure: audio_base64=None, error logged backend-only — never raised
-
-    Args:
-        tts_service: TTS engine instance (TTSService ABC)
-        mapper: EmotionMotionMapper for emotion → keyframes
-        text: Text to synthesize
-        emotion: Detected emotion tag (None → mapper returns default)
-        sequence: Chunk order within turn (starts at 0)
-        tts_enabled: False → skip TTS API entirely
-        reference_id: Voice reference ID. None → engine default
-
-    Returns:
-        TtsChunkMessage with audio_base64=None on failure/disabled,
-        keyframes always populated.
-    """
+    # 1. Generate emotion keyframes (always)
     keyframes: list[TimelineKeyframe] = mapper.map(emotion)
-    audio: str | None = None
 
-    if tts_enabled:
-        try:
-            result = await to_thread(
-                tts_service.generate_speech,
-                text,
-                reference_id,
-                "base64",
-                audio_format="wav",
-            )
-            if result is None:
-                logger.error(f"TTS synthesis returned None for sequence {sequence}")
-                audio = None
-            else:
-                audio = result
-        except Exception as e:
-            logger.error(f"TTS synthesis failed for sequence {sequence}: {e}")
-            audio = None
+    audio_base64: str | None = None
+
+    if not tts_enabled:
+        return TtsChunkMessage(
+            sequence=sequence,
+            text=text,
+            audio_base64=None,
+            emotion=emotion,
+            keyframes=keyframes,
+        )
+
+    # 2. Generate speech as raw bytes first (for duration calculation)
+    try:
+        audio_bytes: bytes | None = await to_thread(
+            tts_service.generate_speech,
+            text,
+            reference_id,
+            "bytes",
+            audio_format="wav",
+        )
+    except Exception:
+        logger.opt(exception=True).warning("[TTS] generate_speech failed")
+        audio_bytes = None
+
+    # 3. If audio succeeded, compute duration and generate visemes
+    if audio_bytes and isinstance(audio_bytes, bytes):
+        audio_base64 = base64.b64encode(audio_bytes).decode("ascii")
+
+        if viseme_mapper is not None:
+            duration = wav_duration(audio_bytes)
+            if duration > 0:
+                # Extract emotion targets from last emotion keyframe
+                emotion_targets: dict[str, float] | None = None
+                if keyframes:
+                    last_kf = keyframes[-1]
+                    if isinstance(last_kf, dict) and "targets" in last_kf:
+                        targets_value = last_kf["targets"]
+                        if isinstance(targets_value, dict):
+                            emotion_targets = targets_value
+
+                viseme_keyframes = viseme_mapper.generate(
+                    text, duration, emotion_targets
+                )
+                if viseme_keyframes:
+                    keyframes = viseme_keyframes
 
     return TtsChunkMessage(
         sequence=sequence,
         text=text,
-        audio_base64=audio,
+        audio_base64=audio_base64,
         emotion=emotion,
         keyframes=keyframes,
     )

--- a/src/services/tts_service/viseme_mapper.py
+++ b/src/services/tts_service/viseme_mapper.py
@@ -86,7 +86,7 @@ class VisemeMapper:
             keyframes.append({"duration": per_phoneme, "targets": targets})
 
         # Closing keyframe: all visemes zero
-        closing_targets: dict[str, float] = {k: 0.0 for k in _VISEME_KEYS}
+        closing_targets: dict[str, float] = dict.fromkeys(_VISEME_KEYS, 0.0)
         if emotion_targets:
             closing_targets.update(emotion_targets)
         keyframes.append({"duration": _CLOSING_DURATION, "targets": closing_targets})

--- a/src/services/tts_service/viseme_mapper.py
+++ b/src/services/tts_service/viseme_mapper.py
@@ -1,0 +1,121 @@
+"""Maps Japanese text to VRM viseme (A/I/U/E/O) keyframes via pyopenjtalk G2P."""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from src.models.websocket import TimelineKeyframe
+
+# Vowel phonemes → VRM viseme name + default weight
+_VOWEL_MAP: dict[str, tuple[str, float]] = {
+    "a": ("A", 0.9),
+    "i": ("I", 0.7),
+    "u": ("U", 0.6),
+    "e": ("E", 0.7),
+    "o": ("O", 0.8),
+}
+
+_VISEME_KEYS = ("A", "I", "U", "E", "O")
+_CLOSING_DURATION = 0.05  # seconds for mouth-close keyframe
+
+
+class VisemeMapper:
+    """Converts Japanese text to timed VRM viseme keyframes.
+
+    Uses pyopenjtalk for grapheme-to-phoneme conversion,
+    then maps each phoneme to A/I/U/E/O visemes with timing
+    proportional to audio duration.
+    """
+
+    def generate(
+        self,
+        text: str,
+        audio_duration: float,
+        emotion_targets: dict[str, float] | None = None,
+    ) -> list[TimelineKeyframe]:
+        """Generate viseme keyframes from Japanese text.
+
+        Args:
+            text: Japanese text to convert to visemes.
+            audio_duration: Duration of the TTS audio in seconds.
+            emotion_targets: Emotion expression values to merge into every keyframe
+                (e.g. {"happy": 1.0}). Prevents ClearAllExpressions from
+                resetting emotions between viseme keyframes.
+
+        Returns:
+            List of TimelineKeyframe dicts. Empty list on failure or invalid input.
+        """
+        if not text or not text.strip() or audio_duration <= 0:
+            return []
+
+        phonemes = self._extract_phonemes(text)
+        if not phonemes:
+            return []
+
+        # Reserve time for closing keyframe
+        main_duration = audio_duration - _CLOSING_DURATION
+        if main_duration <= 0:
+            return []
+
+        per_phoneme = main_duration / len(phonemes)
+        keyframes: list[TimelineKeyframe] = []
+
+        for idx, phoneme in enumerate(phonemes):
+            targets: dict[str, float] = {}
+
+            # Always include all 5 viseme keys explicitly
+            vowel = self._phoneme_to_vowel(phoneme)
+            if vowel:
+                viseme_name, weight = vowel
+                for k in _VISEME_KEYS:
+                    targets[k] = weight if k == viseme_name else 0.0
+            else:
+                # Consonant/N/silence: check for coarticulation
+                next_vowel = self._next_vowel(phonemes, idx)
+                for k in _VISEME_KEYS:
+                    if next_vowel and k == next_vowel[0]:
+                        targets[k] = next_vowel[1] * 0.3  # coarticulation
+                    else:
+                        targets[k] = 0.0
+
+            # Merge emotion targets
+            if emotion_targets:
+                targets.update(emotion_targets)
+
+            keyframes.append({"duration": per_phoneme, "targets": targets})
+
+        # Closing keyframe: all visemes zero
+        closing_targets: dict[str, float] = {k: 0.0 for k in _VISEME_KEYS}
+        if emotion_targets:
+            closing_targets.update(emotion_targets)
+        keyframes.append({"duration": _CLOSING_DURATION, "targets": closing_targets})
+
+        return keyframes
+
+    def _extract_phonemes(self, text: str) -> list[str]:
+        """Extract phoneme list from text using pyopenjtalk."""
+        try:
+            import pyopenjtalk
+
+            raw = pyopenjtalk.g2p(text)
+            if not raw:
+                return []
+            # pyopenjtalk returns space-separated phonemes like "k o N n i ch i w a"
+            return [p for p in raw.split() if p]
+        except Exception:
+            logger.warning(f"[Viseme] pyopenjtalk.g2p failed for text: {text[:30]}")
+            return []
+
+    def _phoneme_to_vowel(self, phoneme: str) -> tuple[str, float] | None:
+        """Map a phoneme to its vowel viseme, or None if consonant/silence."""
+        return _VOWEL_MAP.get(phoneme.lower())
+
+    def _next_vowel(
+        self, phonemes: list[str], current_idx: int
+    ) -> tuple[str, float] | None:
+        """Find the next vowel after current_idx for coarticulation."""
+        for i in range(current_idx + 1, min(current_idx + 3, len(phonemes))):
+            v = self._phoneme_to_vowel(phonemes[i])
+            if v:
+                return v
+        return None

--- a/src/services/tts_service/viseme_mapper.py
+++ b/src/services/tts_service/viseme_mapper.py
@@ -17,6 +17,7 @@ _VOWEL_MAP: dict[str, tuple[str, float]] = {
 
 _VISEME_KEYS = ("A", "I", "U", "E", "O")
 _CLOSING_DURATION = 0.05  # seconds for mouth-close keyframe
+_COARTICULATION_WEIGHT = 0.3  # Consonant mouth shape blends to 30% of next vowel
 
 
 class VisemeMapper:
@@ -74,7 +75,7 @@ class VisemeMapper:
                 next_vowel = self._next_vowel(phonemes, idx)
                 for k in _VISEME_KEYS:
                     if next_vowel and k == next_vowel[0]:
-                        targets[k] = next_vowel[1] * 0.3  # coarticulation
+                        targets[k] = next_vowel[1] * _COARTICULATION_WEIGHT
                     else:
                         targets[k] = 0.0
 

--- a/src/services/websocket_service/message_processor/event_handlers.py
+++ b/src/services/websocket_service/message_processor/event_handlers.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from src.services.service_manager import get_viseme_mapper
 from src.services.tts_service.tts_pipeline import synthesize_chunk
 from src.services.websocket_service.text_processors import (
     TextChunkProcessor,
@@ -299,6 +300,7 @@ class EventHandler:
             sequence=sequence,
             tts_enabled=tts_enabled,
             reference_id=reference_id,
+            viseme_mapper=get_viseme_mapper(),
         )
 
         if self.processor.is_connection_closing():

--- a/tests/api/test_tts_flow_integration.py
+++ b/tests/api/test_tts_flow_integration.py
@@ -53,6 +53,8 @@ async def _fake_synthesize_and_send(
 
 async def test_tts_enabled_normal_flow(processor: MessageProcessor):
     """tts_chunk received, audio non-null, sequence order, stream_end last."""
+    # Pipeline now expects bytes from generate_speech (see synthesize_chunk).
+    processor.tts_service.generate_speech.return_value = b"\x00\x01\x02\x03"
 
     async def agent_stream() -> AsyncIterator[dict[str, Any]]:
         yield {"type": "stream_start"}

--- a/tests/services/test_tts_pipeline.py
+++ b/tests/services/test_tts_pipeline.py
@@ -4,15 +4,21 @@ Note: asyncio_mode=auto (pyproject.toml) — @pytest.mark.asyncio decorator is N
 generate_speech() MUST be mocked in all tests — no real TTS engine in CI.
 """
 
+import base64 as _b64
 from unittest.mock import MagicMock, patch
 
 from src.services.tts_service.tts_pipeline import synthesize_chunk
 
 
 async def test_synthesize_chunk_success():
-    """TTS success: audio_base64 non-null, keyframes populated from mapper."""
+    """TTS success: audio_base64 non-null, keyframes populated from mapper.
+
+    viseme_mapper is None here — exercises the backwards-compatible branch
+    where the pipeline just base64-encodes raw bytes from generate_speech.
+    """
+    raw_audio = b"\x00\x01\x02\x03"
     tts_service = MagicMock()
-    tts_service.generate_speech.return_value = "base64encodedaudio=="
+    tts_service.generate_speech.return_value = raw_audio
     mapper = MagicMock()
     mapper.map.return_value = [{"duration": 0.3, "targets": {"happy": 1.0}}]
 
@@ -25,7 +31,7 @@ async def test_synthesize_chunk_success():
         tts_enabled=True,
     )
 
-    assert chunk.audio_base64 == "base64encodedaudio=="
+    assert chunk.audio_base64 == _b64.b64encode(raw_audio).decode("ascii")
     assert chunk.keyframes == [{"duration": 0.3, "targets": {"happy": 1.0}}]
     assert chunk.sequence == 0
     assert chunk.text == "안녕"
@@ -36,7 +42,7 @@ async def test_synthesize_chunk_success():
 async def test_synthesize_chunk_uses_wav_format():
     """generate_speech must be called with 'wav' audio format."""
     tts_service = MagicMock()
-    tts_service.generate_speech.return_value = "wavbase64=="
+    tts_service.generate_speech.return_value = b"\x00\x01\x02\x03"
     mapper = MagicMock()
     mapper.map.return_value = [{"duration": 0.3, "targets": {"neutral": 1.0}}]
 
@@ -58,30 +64,28 @@ async def test_synthesize_chunk_uses_wav_format():
 
 
 async def test_synthesize_chunk_generate_speech_returns_none():
-    """generate_speech returns None → audio=None, logger.error called once."""
+    """generate_speech returns None → audio=None, keyframes still populated."""
     tts_service = MagicMock()
     tts_service.generate_speech.return_value = None
     mapper = MagicMock()
     mapper.map.return_value = [{"duration": 0.3, "targets": {"neutral": 1.0}}]
 
-    with patch("src.services.tts_service.tts_pipeline.logger") as mock_logger:
-        chunk = await synthesize_chunk(
-            tts_service=tts_service,
-            mapper=mapper,
-            text="텍스트",
-            emotion=None,
-            sequence=1,
-            tts_enabled=True,
-        )
+    chunk = await synthesize_chunk(
+        tts_service=tts_service,
+        mapper=mapper,
+        text="텍스트",
+        emotion=None,
+        sequence=1,
+        tts_enabled=True,
+    )
 
     assert chunk.audio_base64 is None
     assert chunk.sequence == 1
     assert chunk.keyframes == [{"duration": 0.3, "targets": {"neutral": 1.0}}]
-    mock_logger.error.assert_called_once()
 
 
 async def test_synthesize_chunk_exception():
-    """generate_speech raises exception → audio=None, logger.error called once."""
+    """generate_speech raises exception → audio=None, logger.warning called once."""
     tts_service = MagicMock()
     tts_service.generate_speech.side_effect = ConnectionError("TTS server down")
     mapper = MagicMock()
@@ -99,7 +103,8 @@ async def test_synthesize_chunk_exception():
 
     assert chunk.audio_base64 is None
     assert chunk.sequence == 2
-    mock_logger.error.assert_called_once()
+    # Pipeline now logs exceptions via logger.opt(exception=True).warning(...)
+    mock_logger.opt.return_value.warning.assert_called_once()
 
 
 async def test_synthesize_chunk_tts_disabled():

--- a/tests/services/test_tts_pipeline.py
+++ b/tests/services/test_tts_pipeline.py
@@ -104,7 +104,33 @@ async def test_synthesize_chunk_exception():
     assert chunk.audio_base64 is None
     assert chunk.sequence == 2
     # Pipeline now logs exceptions via logger.opt(exception=True).warning(...)
+    mock_logger.opt.assert_called_once_with(exception=True)
     mock_logger.opt.return_value.warning.assert_called_once()
+    args, _ = mock_logger.opt.return_value.warning.call_args
+    assert args and "TTS" in args[0]
+
+
+async def test_synthesize_chunk_warns_on_none_return():
+    """generate_speech returns None → audio=None, logger.warning called once."""
+    tts_service = MagicMock()
+    tts_service.generate_speech.return_value = None
+    mapper = MagicMock()
+    mapper.map.return_value = [{"duration": 0.3, "targets": {"neutral": 1.0}}]
+
+    with patch("src.services.tts_service.tts_pipeline.logger") as mock_logger:
+        chunk = await synthesize_chunk(
+            tts_service=tts_service,
+            mapper=mapper,
+            text="텍스트",
+            emotion=None,
+            sequence=7,
+            tts_enabled=True,
+        )
+
+    assert chunk.audio_base64 is None
+    mock_logger.warning.assert_called_once()
+    args, _ = mock_logger.warning.call_args
+    assert args and "TTS" in args[0] and "sequence 7" in args[0]
 
 
 async def test_synthesize_chunk_tts_disabled():

--- a/tests/unit/test_tts_pipeline_viseme.py
+++ b/tests/unit/test_tts_pipeline_viseme.py
@@ -1,0 +1,117 @@
+"""Tests for viseme integration in tts_pipeline.synthesize_chunk."""
+
+import base64
+import struct
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.tts_service.emotion_motion_mapper import EmotionMotionMapper
+from src.services.tts_service.tts_pipeline import synthesize_chunk
+from src.services.tts_service.viseme_mapper import VisemeMapper
+
+
+def _make_wav_bytes(duration_seconds: float = 1.0) -> bytes:
+    """Create WAV bytes with specified duration."""
+    sample_rate = 22050
+    channels = 1
+    bits = 16
+    num_samples = int(sample_rate * duration_seconds)
+    bytes_per_sample = bits // 8
+    data_size = num_samples * channels * bytes_per_sample
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF", 36 + data_size, b"WAVE",
+        b"fmt ", 16, 1, channels, sample_rate,
+        sample_rate * channels * bytes_per_sample,
+        channels * bytes_per_sample, bits,
+        b"data", data_size,
+    )
+    return header + b"\x00" * data_size
+
+
+@pytest.fixture
+def tts_service():
+    svc = MagicMock()
+    svc.generate_speech.return_value = _make_wav_bytes(1.0)
+    return svc
+
+
+@pytest.fixture
+def emotion_mapper():
+    return EmotionMotionMapper(
+        {"😊": {"keyframes": [{"duration": 0.3, "targets": {"happy": 1.0}}]}}
+    )
+
+
+@pytest.fixture
+def viseme_mapper():
+    return VisemeMapper()
+
+
+@pytest.mark.asyncio
+async def test_viseme_keyframes_in_output(tts_service, emotion_mapper, viseme_mapper):
+    """synthesize_chunk should produce keyframes with A/I/U/E/O visemes."""
+    msg = await synthesize_chunk(
+        tts_service=tts_service,
+        mapper=emotion_mapper,
+        viseme_mapper=viseme_mapper,
+        text="こんにちは",
+        emotion="😊",
+        sequence=0,
+        tts_enabled=True,
+    )
+    assert msg.audio_base64 is not None
+    assert len(msg.keyframes) > 0
+    # Viseme keyframes should have A/I/U/E/O keys
+    has_viseme = any("A" in kf["targets"] for kf in msg.keyframes)
+    assert has_viseme, "Keyframes should contain viseme targets"
+
+
+@pytest.mark.asyncio
+async def test_emotion_merged_in_viseme_keyframes(tts_service, emotion_mapper, viseme_mapper):
+    """Emotion targets should be present in viseme keyframes."""
+    msg = await synthesize_chunk(
+        tts_service=tts_service,
+        mapper=emotion_mapper,
+        viseme_mapper=viseme_mapper,
+        text="こんにちは",
+        emotion="😊",
+        sequence=0,
+    )
+    # Every keyframe should have happy emotion merged
+    for kf in msg.keyframes:
+        assert kf["targets"].get("happy") == 1.0, f"Missing happy in {kf}"
+
+
+@pytest.mark.asyncio
+async def test_tts_disabled_still_has_emotion_keyframes(tts_service, emotion_mapper, viseme_mapper):
+    """When TTS disabled, should fall back to emotion-only keyframes."""
+    msg = await synthesize_chunk(
+        tts_service=tts_service,
+        mapper=emotion_mapper,
+        viseme_mapper=viseme_mapper,
+        text="こんにちは",
+        emotion="😊",
+        sequence=0,
+        tts_enabled=False,
+    )
+    assert msg.audio_base64 is None
+    assert len(msg.keyframes) > 0  # emotion keyframes still present
+
+
+@pytest.mark.asyncio
+async def test_tts_failure_falls_back(tts_service, emotion_mapper, viseme_mapper):
+    """When TTS fails, should fall back to emotion-only keyframes."""
+    tts_service.generate_speech.return_value = None
+    msg = await synthesize_chunk(
+        tts_service=tts_service,
+        mapper=emotion_mapper,
+        viseme_mapper=viseme_mapper,
+        text="こんにちは",
+        emotion="😊",
+        sequence=0,
+    )
+    assert msg.audio_base64 is None
+    # Should still have emotion keyframes
+    assert len(msg.keyframes) > 0

--- a/tests/unit/test_tts_pipeline_viseme.py
+++ b/tests/unit/test_tts_pipeline_viseme.py
@@ -2,7 +2,7 @@
 
 import base64
 import struct
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -49,7 +49,6 @@ def viseme_mapper():
     return VisemeMapper()
 
 
-@pytest.mark.asyncio
 async def test_viseme_keyframes_in_output(tts_service, emotion_mapper, viseme_mapper):
     """synthesize_chunk should produce keyframes with A/I/U/E/O visemes."""
     msg = await synthesize_chunk(
@@ -68,7 +67,6 @@ async def test_viseme_keyframes_in_output(tts_service, emotion_mapper, viseme_ma
     assert has_viseme, "Keyframes should contain viseme targets"
 
 
-@pytest.mark.asyncio
 async def test_emotion_merged_in_viseme_keyframes(tts_service, emotion_mapper, viseme_mapper):
     """Emotion targets should be present in viseme keyframes."""
     msg = await synthesize_chunk(
@@ -84,7 +82,6 @@ async def test_emotion_merged_in_viseme_keyframes(tts_service, emotion_mapper, v
         assert kf["targets"].get("happy") == 1.0, f"Missing happy in {kf}"
 
 
-@pytest.mark.asyncio
 async def test_tts_disabled_still_has_emotion_keyframes(tts_service, emotion_mapper, viseme_mapper):
     """When TTS disabled, should fall back to emotion-only keyframes."""
     msg = await synthesize_chunk(
@@ -100,7 +97,6 @@ async def test_tts_disabled_still_has_emotion_keyframes(tts_service, emotion_map
     assert len(msg.keyframes) > 0  # emotion keyframes still present
 
 
-@pytest.mark.asyncio
 async def test_tts_failure_falls_back(tts_service, emotion_mapper, viseme_mapper):
     """When TTS fails, should fall back to emotion-only keyframes."""
     tts_service.generate_speech.return_value = None

--- a/tests/unit/test_tts_pipeline_viseme.py
+++ b/tests/unit/test_tts_pipeline_viseme.py
@@ -1,6 +1,5 @@
 """Tests for viseme integration in tts_pipeline.synthesize_chunk."""
 
-import base64
 import struct
 from unittest.mock import MagicMock
 
@@ -21,11 +20,19 @@ def _make_wav_bytes(duration_seconds: float = 1.0) -> bytes:
     data_size = num_samples * channels * bytes_per_sample
     header = struct.pack(
         "<4sI4s4sIHHIIHH4sI",
-        b"RIFF", 36 + data_size, b"WAVE",
-        b"fmt ", 16, 1, channels, sample_rate,
+        b"RIFF",
+        36 + data_size,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        channels,
+        sample_rate,
         sample_rate * channels * bytes_per_sample,
-        channels * bytes_per_sample, bits,
-        b"data", data_size,
+        channels * bytes_per_sample,
+        bits,
+        b"data",
+        data_size,
     )
     return header + b"\x00" * data_size
 
@@ -67,7 +74,9 @@ async def test_viseme_keyframes_in_output(tts_service, emotion_mapper, viseme_ma
     assert has_viseme, "Keyframes should contain viseme targets"
 
 
-async def test_emotion_merged_in_viseme_keyframes(tts_service, emotion_mapper, viseme_mapper):
+async def test_emotion_merged_in_viseme_keyframes(
+    tts_service, emotion_mapper, viseme_mapper
+):
     """Emotion targets should be present in viseme keyframes."""
     msg = await synthesize_chunk(
         tts_service=tts_service,
@@ -82,7 +91,9 @@ async def test_emotion_merged_in_viseme_keyframes(tts_service, emotion_mapper, v
         assert kf["targets"].get("happy") == 1.0, f"Missing happy in {kf}"
 
 
-async def test_tts_disabled_still_has_emotion_keyframes(tts_service, emotion_mapper, viseme_mapper):
+async def test_tts_disabled_still_has_emotion_keyframes(
+    tts_service, emotion_mapper, viseme_mapper
+):
     """When TTS disabled, should fall back to emotion-only keyframes."""
     msg = await synthesize_chunk(
         tts_service=tts_service,

--- a/tests/unit/test_viseme_mapper.py
+++ b/tests/unit/test_viseme_mapper.py
@@ -1,0 +1,129 @@
+"""Tests for VisemeMapper — text to viseme keyframe generation."""
+
+import pytest
+
+from src.services.tts_service.viseme_mapper import VisemeMapper
+
+
+class TestPhonemeToViseme:
+    """Test Japanese phoneme → VRM viseme mapping."""
+
+    def setup_method(self):
+        self.mapper = VisemeMapper()
+
+    def test_simple_vowel_a(self):
+        """Single vowel 'あ' → one A keyframe + closing keyframe."""
+        result = self.mapper.generate("あ", audio_duration=0.5)
+        # Should have at least 2 keyframes (phoneme + closing)
+        assert len(result) >= 2
+        # First keyframe should have A viseme active
+        assert result[0]["targets"]["A"] > 0
+        # Last keyframe should close mouth (all visemes 0)
+        last = result[-1]
+        assert last["targets"]["A"] == 0
+        assert last["targets"]["I"] == 0
+
+    def test_konnichiwa_phoneme_count(self):
+        """'こんにちは' → keyframes for each phoneme + closing."""
+        result = self.mapper.generate("こんにちは", audio_duration=1.0)
+        # pyopenjtalk produces ~9 phonemes for こんにちは
+        # plus 1 closing keyframe
+        assert len(result) >= 5  # at minimum vowels + closing
+
+    def test_konnichiwa_viseme_values(self):
+        """'こんにちは' should map to O, (N), I, I, A visemes."""
+        result = self.mapper.generate("こんにちは", audio_duration=1.0)
+        # Collect non-zero visemes from keyframes (excluding closing)
+        visemes = []
+        for kf in result[:-1]:  # skip closing keyframe
+            targets = kf["targets"]
+            for v in ("A", "I", "U", "E", "O"):
+                if targets.get(v, 0) > 0.5:
+                    visemes.append(v)
+                    break
+        # Should contain O (ko), I (ni), I (chi), A (wa) at minimum
+        assert "O" in visemes
+        assert "I" in visemes
+        assert "A" in visemes
+
+    def test_duration_distribution(self):
+        """Total keyframe durations should approximately equal audio_duration."""
+        result = self.mapper.generate("こんにちは", audio_duration=1.0)
+        total = sum(kf["duration"] for kf in result)
+        assert abs(total - 1.0) < 0.1  # within 100ms tolerance
+
+    def test_closing_keyframe(self):
+        """Last keyframe should have all visemes at 0 and short duration."""
+        result = self.mapper.generate("テスト", audio_duration=0.5)
+        last = result[-1]
+        assert last["duration"] == pytest.approx(0.05, abs=0.01)
+        for v in ("A", "I", "U", "E", "O"):
+            assert last["targets"][v] == 0
+
+    def test_all_visemes_explicit_in_every_keyframe(self):
+        """Every keyframe must contain all 5 viseme keys (even if 0)."""
+        result = self.mapper.generate("あいうえお", audio_duration=1.0)
+        for kf in result:
+            for v in ("A", "I", "U", "E", "O"):
+                assert v in kf["targets"], f"Missing {v} in keyframe targets"
+
+
+class TestEmotionMerging:
+    """Test emotion targets merged into viseme keyframes."""
+
+    def setup_method(self):
+        self.mapper = VisemeMapper()
+
+    def test_emotion_targets_merged(self):
+        """Emotion targets should appear in every keyframe."""
+        emotion = {"happy": 1.0}
+        result = self.mapper.generate("あ", audio_duration=0.5, emotion_targets=emotion)
+        for kf in result:
+            assert kf["targets"]["happy"] == 1.0
+
+    def test_no_emotion_targets(self):
+        """Without emotion_targets, keyframes should only have visemes."""
+        result = self.mapper.generate("あ", audio_duration=0.5)
+        for kf in result:
+            assert "happy" not in kf["targets"]
+
+    def test_multiple_emotion_targets(self):
+        """Multiple emotion targets should all be present."""
+        emotion = {"happy": 0.8, "fun": 0.5}
+        result = self.mapper.generate("あ", audio_duration=0.5, emotion_targets=emotion)
+        for kf in result:
+            assert kf["targets"]["happy"] == 0.8
+            assert kf["targets"]["fun"] == 0.5
+
+
+class TestEdgeCases:
+    """Test edge cases and graceful degradation."""
+
+    def setup_method(self):
+        self.mapper = VisemeMapper()
+
+    def test_empty_text(self):
+        """Empty text returns empty keyframes."""
+        result = self.mapper.generate("", audio_duration=0.5)
+        assert result == []
+
+    def test_zero_duration(self):
+        """Zero audio duration returns empty keyframes."""
+        result = self.mapper.generate("こんにちは", audio_duration=0.0)
+        assert result == []
+
+    def test_non_japanese_text(self):
+        """Non-Japanese text: graceful degradation (empty or best-effort)."""
+        result = self.mapper.generate("hello world", audio_duration=1.0)
+        # Should not raise, may return empty or best-effort
+        assert isinstance(result, list)
+
+    def test_mixed_text(self):
+        """Mixed Japanese/non-Japanese should not raise."""
+        result = self.mapper.generate("Hello こんにちは World", audio_duration=1.0)
+        assert isinstance(result, list)
+
+    def test_negative_duration(self):
+        """Negative duration returns empty keyframes."""
+        result = self.mapper.generate("あ", audio_duration=-1.0)
+        assert result == []

--- a/tests/unit/test_wav_duration.py
+++ b/tests/unit/test_wav_duration.py
@@ -1,0 +1,51 @@
+"""Tests for WAV duration calculation utility."""
+
+import struct
+
+import pytest
+
+from src.services.tts_service.tts_pipeline import wav_duration
+
+
+def _make_wav(sample_rate: int, channels: int, bits: int, num_samples: int) -> bytes:
+    """Create a minimal WAV file in memory."""
+    bytes_per_sample = bits // 8
+    data_size = num_samples * channels * bytes_per_sample
+    # RIFF header
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + data_size,  # file size - 8
+        b"WAVE",
+        b"fmt ",
+        16,  # fmt chunk size
+        1,  # PCM format
+        channels,
+        sample_rate,
+        sample_rate * channels * bytes_per_sample,  # byte rate
+        channels * bytes_per_sample,  # block align
+        bits,  # bits per sample
+        b"data",
+        data_size,
+    )
+    return header + b"\x00" * data_size
+
+
+class TestWavDuration:
+    def test_one_second_mono_16bit(self):
+        wav = _make_wav(sample_rate=22050, channels=1, bits=16, num_samples=22050)
+        assert wav_duration(wav) == pytest.approx(1.0, abs=0.01)
+
+    def test_half_second_stereo_16bit(self):
+        wav = _make_wav(sample_rate=44100, channels=2, bits=16, num_samples=22050)
+        assert wav_duration(wav) == pytest.approx(0.5, abs=0.01)
+
+    def test_empty_data(self):
+        wav = _make_wav(sample_rate=22050, channels=1, bits=16, num_samples=0)
+        assert wav_duration(wav) == 0.0
+
+    def test_invalid_bytes(self):
+        assert wav_duration(b"not a wav") == 0.0
+
+    def test_none_input(self):
+        assert wav_duration(None) == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -713,6 +713,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
+    { name = "pyopenjtalk-plus" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -788,6 +789,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "pymongo", specifier = ">=4.15.3" },
+    { name = "pyopenjtalk-plus", specifier = ">=0.4.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
@@ -3206,6 +3208,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenjtalk-plus"
+version = "0.4.1.post8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "sudachidict-core" },
+    { name = "sudachipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/de/004b053d6e5a319dd5072a74aa2bd68e71a8ba5f3acdf6e78381aed94898/pyopenjtalk_plus-0.4.1.post8.tar.gz", hash = "sha256:f4dfbfbe9021d33c708f04ca5a27008c4f72a9fed097718ca3234d318a7a45e1", size = 24935840, upload-time = "2026-03-30T22:16:07.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/02/5856b7a2ee74cd3fef8b807b529d49b73aee26225e8108fc3403e4864ab7/pyopenjtalk_plus-0.4.1.post8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4bb5d3b7334eac2aa06efd30a367584f13682dc01c15e54b80ceae697a7c5242", size = 25490616, upload-time = "2026-03-30T22:15:32.406Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/97/83491b337395c536be5646f2609db9fd1ddd6bdc1d8bff44090e4ee93c8f/pyopenjtalk_plus-0.4.1.post8-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f325b552cbcfce7766b0eb566d3b577249c1b0f47808c5f548cf91f034583ab", size = 30875872, upload-time = "2026-03-30T22:15:35.46Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/894b7624663b3d7c85264bd6ff7d334513de418af8b16b2b5a9dc9c5ef67/pyopenjtalk_plus-0.4.1.post8-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09d31ec3ee2563d89648d6037793948ba5d3f634ee0d331fc539d61e901242b5", size = 30959112, upload-time = "2026-03-30T22:15:38.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c2/5e787b8678f3ef3e004363071eeeaa02ee68ed06ed8659d8100fb987b304/pyopenjtalk_plus-0.4.1.post8-cp313-cp313-win_amd64.whl", hash = "sha256:1e5dee0b0bb0b04303a8995278e87315bee1c37cf48b2bf2052704d54b87194b", size = 24751015, upload-time = "2026-03-30T22:15:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e8/ea015745673add985e28aa9ca334b9f25589f0ca0ee6b6b00f6b9cb042e6/pyopenjtalk_plus-0.4.1.post8-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c4f38efc6553bc8cf73643062cbff9a9911cdb0054c9a0f3b148fb6d8d1371a9", size = 25492079, upload-time = "2026-03-30T22:15:43.858Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f1/8edf559e0b85296c28c18c113bc62d26eb24b3c3cfa007b937583a2d18f1/pyopenjtalk_plus-0.4.1.post8-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b087cd8018ecd98948e0ad9a7619b136de453ebb8abafb7b6ba0e68d08e8e1ea", size = 30872048, upload-time = "2026-03-30T22:15:46.562Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d5/7b92e8a5cf4ce7318d48a10d7dabf063826b7333701c82c7b778f1f01ccd/pyopenjtalk_plus-0.4.1.post8-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb65c83d632ee48cae78686c3b908553add5e0f14d55f5b194374c40d77fffd6", size = 30946357, upload-time = "2026-03-30T22:15:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9d/3911562c71312ada4caf18a5f0d3fb787a0b72248ce030027da513bc6be9/pyopenjtalk_plus-0.4.1.post8-cp314-cp314-win_amd64.whl", hash = "sha256:5e4e46607178d242490dc8d29bff2abbdf9f30d128d1bbb7e015010c29c485d3", size = 25426929, upload-time = "2026-03-30T22:15:52.116Z" },
+]
+
+[[package]]
 name = "pypdf"
 version = "6.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3934,6 +3957,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "sudachidict-core"
+version = "20260116"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sudachipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/f9/92f818db5d18c54d9a456fdaa5cb4eb0848464fc48888f37f91b0112c2fc/sudachidict_core-20260116.tar.gz", hash = "sha256:81d3c8bbd880a58de33f9fb441663f46fb46a97b829d7ba7598f7085fedf319e", size = 9054, upload-time = "2026-01-20T02:56:34.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/6a/dbf407b0a3b04ae9815e2b66997c60a9ae7c76e61ec0a2d5653745633400/sudachidict_core-20260116-py3-none-any.whl", hash = "sha256:6f0ab1d3ba074d36d487cfcb4dde9fa1aacd96d3d3559bc8691d3ed9c468b157", size = 72170257, upload-time = "2026-01-20T02:57:56.462Z" },
+]
+
+[[package]]
+name = "sudachipy"
+version = "0.6.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/34/a52dc020e1ac67ffe2469d22771a850589a1184e0d91d48addd364ee02ba/sudachipy-0.6.11.tar.gz", hash = "sha256:4f03310fd3fc779b3000f49395c939d18a30081632d3cb14488426f7c07cc526", size = 180616, upload-time = "2026-04-13T05:27:26.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/71/4d4a6b771fef1571d2f6e73d25ffcb3e8de462af674464c1fd41c9787899/sudachipy-0.6.11-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f38624fc01c2bb087c875a32750e3735b67b6b66487ac30a8e3f2d3599c4e3ea", size = 2964705, upload-time = "2026-04-13T05:26:46.895Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6f/cc4b530725321c098dbaf57fdc74306e22224b8b5c5fd88feaf8a501aa20/sudachipy-0.6.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a07a9a9232137353bb96d1ae2ce7e33def1ac48b571e338b3433b90581a9bbb", size = 1526522, upload-time = "2026-04-13T05:26:48.038Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a8/94cbedeef4179536ee716504bdf5772060944dce7fa6cf0d3648c50a46de/sudachipy-0.6.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d074154c652ed6637a6a3581c67346ce642e47173e849267deb8c711b74157c4", size = 1461288, upload-time = "2026-04-13T05:26:49.388Z" },
+    { url = "https://files.pythonhosted.org/packages/98/52/447115dc0a638081fd3f48a54f4ac8f455847366504fc68029ab1b7bd59b/sudachipy-0.6.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b87831c5f98d634da04629bb6e3cace2a9aee275e83c1b62c8fdd7da4aca2876", size = 1582788, upload-time = "2026-04-13T05:26:50.664Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/1b2cbdc8f1a889b76db9aad5599a86ed08d894a197b41dcdab265b1f8440/sudachipy-0.6.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc86a6832448a56bcc6200b078a9bebd6059d925328214b96ee6b8830b8d34ab", size = 1627623, upload-time = "2026-04-13T05:26:52.701Z" },
+    { url = "https://files.pythonhosted.org/packages/69/4a/d5c1021335edfe8d0e78befb591fb11f4f8543bc0db1acf0ffc4ba135650/sudachipy-0.6.11-cp313-cp313-win_amd64.whl", hash = "sha256:c56d8308e799bff8f0edc0a9921f0bacf9b0b65c5c5df031022a048402f1d9ac", size = 1326405, upload-time = "2026-04-13T05:26:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/db/20/c1ed0b8ab7a9f21d8954659de8113c5ae2f3a1667f21260b408038a94d78/sudachipy-0.6.11-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ca04ecca9530d7b663f34f32309ad0961b3f85a8921908ecf39274e00522b598", size = 2963252, upload-time = "2026-04-13T05:26:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a3/064353cbc163866aaf42f7735c9b85ea1ff8376ae1ad1b0a60f5a4e97a35/sudachipy-0.6.11-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:445cd4f8596d308582743cc48425b2c0aebcda04b37b7f18e00ad927d86194b1", size = 1525951, upload-time = "2026-04-13T05:26:57.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2c/022b1c2e491bddfd2daa488314973f864941992e20d602e8713672b37765/sudachipy-0.6.11-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b49d244423c39acb6ffa44a32c0296464f7454213f872d8738e9c43db4bc33d4", size = 1460367, upload-time = "2026-04-13T05:26:58.719Z" },
+    { url = "https://files.pythonhosted.org/packages/02/51/42de4a2cb82e428b3f2d04cc5f40370477724429f6dcb5acadb3af488128/sudachipy-0.6.11-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f7d234e77577ac62fb207e65bb925bdec08fb8a3ac8df52302d3903fd581e26", size = 1581432, upload-time = "2026-04-13T05:26:59.836Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e9/b6fb38b6788fdbdeb5e08c26200468a636df4e0ed8fb85b44572e184f6e5/sudachipy-0.6.11-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2e5316b6279c93eca1b325a0f6eda16c284d647daaa1215ee994dd9c543decd4", size = 1627693, upload-time = "2026-04-13T05:27:00.929Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ad/4b7d895e47924195f2feb0f07c4379cd6973b321200aa2ca7046e04e7e57/sudachipy-0.6.11-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:0fa6c8279d2eaa4abf9f4d2921708a518be019cd32894546640ac1f60060b600", size = 2961076, upload-time = "2026-04-13T05:27:02.42Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e5/972d5fc4af5f114b081e3280e669b91a5b6a1cb2740c4efb06b3f9748d07/sudachipy-0.6.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:bc4e9c0882d0b44dea4955416a9e862a80c8d73802ec90546b268d575e4ed985", size = 1524973, upload-time = "2026-04-13T05:27:03.744Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/8734144dbfb7c30d2ffc19a50442b07ad1db9563b6acccd1434e0716ce37/sudachipy-0.6.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:16c99b6f54c5b9e490cacd2a6f773115b9999226ef365c9fb5d88077ec01a96f", size = 1459634, upload-time = "2026-04-13T05:27:04.835Z" },
+    { url = "https://files.pythonhosted.org/packages/19/15/fab04da917e0d73b937dfe1a1886db913ef6a53def93686e81403fdb4aec/sudachipy-0.6.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9ce45838a633d708761ad86bda165076dbcb9c08bba3c9b8cba6ed9b50c6a917", size = 1581548, upload-time = "2026-04-13T05:27:06.504Z" },
+    { url = "https://files.pythonhosted.org/packages/41/df/468830dac0c56be104dd46cd91d20229f7d194705552f2916f0c45766a54/sudachipy-0.6.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0dcdb872648fa0678880cc21c09c5fc9928eb997321a5ecc2916a51697be6fb4", size = 1623217, upload-time = "2026-04-13T05:27:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3b/498efb8fccf32b9e3032e74ec0c54004d070517c507a6546d9cd3c726507/sudachipy-0.6.11-cp314-cp314-win_amd64.whl", hash = "sha256:7392701cb6f97926b61e82362b8c438e53ffffa9b8be7b01bb4e550cade54406", size = 1386569, upload-time = "2026-04-13T05:27:09.131Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d7/f30121219d1be9dd41dc1d444f6d66cf11c1b7bbcd02cdcf326fa4c97456/sudachipy-0.6.11-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:92f5152a8ef8174c46dd78906ef60d0f5b1eca29471fe2574eb018d088f86980", size = 2961196, upload-time = "2026-04-13T05:27:10.346Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/138f9a4189b63c90312088f876817c89143e34a27b703e8b5b39e2cfcffe/sudachipy-0.6.11-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:7448cbf2efca7c03c620853aefee7e7a3a383e72dbd336fe7bb70aa72b7f982c", size = 1525213, upload-time = "2026-04-13T05:27:11.601Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e5/914fa9aa8075ac8e06b95d876a151488b766f17d0e796bba7f1ca8073a4a/sudachipy-0.6.11-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:43c82d7932f00ea7b10707e4dc8c435cea1d4d4984ed020fda6b0b6e33f8a0cd", size = 1458970, upload-time = "2026-04-13T05:27:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/57/46/6e72b5d96646b472ccce0bd75d2e2318963f1bdda95cc92f7761ebc86ff1/sudachipy-0.6.11-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:263083769bb6a60c3b4d98d789ea860c39354bb078ab17fd1418b56e1d58280e", size = 1580002, upload-time = "2026-04-13T05:27:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/eb7c3e8b9dd8d2b9759830239869328a50764bd406d00ba1fe6a8eb70d81/sudachipy-0.6.11-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d49c97ae999f78e8d11f6b5a5da4909d7e8ee7fa1ab650047db97ed1dcee642", size = 1625145, upload-time = "2026-04-13T05:27:16.511Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Japanese text → VRM viseme (A/I/U/E/O) keyframe generation to the TTS pipeline. Viseme keyframes are timed proportionally to WAV audio duration and merged with existing emotion targets so `ClearAllExpressions` can't strip emotion between lip-sync frames.

- New `VisemeMapper` (`src/services/tts_service/viseme_mapper.py`) uses pyopenjtalk G2P → A/I/U/E/O mapping with coarticulation lookahead.
- New `wav_duration` utility parses RIFF/WAVE PCM headers; never raises.
- `synthesize_chunk` switched from `"base64"` to `"bytes"` TTS mode to enable duration calculation; audio is base64-encoded client-side. Backward compatible — `viseme_mapper` is an optional kwarg.
- Hardened logging (warning on `generate_speech` None return, exception boundary around `viseme_mapper.generate`) and stateless singleton in `service_manager`.
- Dependency: `pyopenjtalk-plus>=0.4.1` (has cp313 Windows wheels; upstream `pyopenjtalk` does not).

## Test Plan

- [x] Unit tests: 14 viseme mapper, 5 wav_duration, 4 pipeline integration, 6 updated tts_pipeline — all pass
- [x] No regressions beyond pre-existing baseline (3 unrelated failures + 19 proactive_service errors)
- [x] `make lint` clean
- [ ] `make e2e` on Linux/macOS host with MongoDB / Qdrant / Neo4j / IrodoriTTS reachable
- [ ] Manual WebSocket inspection: Unity client → TTS-enabled chat → confirm `tts_chunk.keyframes` contains `A/I/U/E/O`, emotion merge, closing zeroed keyframe

## Plan reference

`docs/superpowers/plans/2026-04-17-backend-viseme-pipeline.md` — all 7 tasks executed via subagent-driven development.